### PR TITLE
Don't check color profile and terminal darkness until absolutely necessary

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -227,10 +227,10 @@ func styleBorder(border string, fg, bg TerminalColor) string {
 	var style = termenv.Style{}
 
 	if fg != noColor {
-		style = style.Foreground(color(fg.value()))
+		style = style.Foreground(ColorProfile().Color(fg.value()))
 	}
 	if bg != noColor {
-		style = style.Background(color(bg.value()))
+		style = style.Background(ColorProfile().Color(bg.value()))
 	}
 
 	return style.Styled(border)


### PR DESCRIPTION
This PR changes internal behavior so that the color profile and terminal background color aren't checked until the values are needed. Once the lookups have been done once they won't be performed again.

Checking the terminal’s background color can potentially be an expensive call, so if the user isn’t using `lipgloss.AdaptiveColor` there’s really no reason to perform the check.

There's also a small API change: `lipgloss.ColorProfile`, a variable containing the color profile value, is now `lipgloss.ColorProfile()`, a function returning the color profile value.