### PR TITLE
Support for legacy Windows consoles

### DIFF
--- a/ansi_unix.go
+++ b/ansi_unix.go
@@ -1,0 +1,6 @@
+// +build !windows
+
+package lipgloss
+
+// enableANSIColors is only needed on Windows.
+func enableANSIColors() {}

--- a/ansi_unix.go
+++ b/ansi_unix.go
@@ -2,5 +2,5 @@
 
 package lipgloss
 
-// enableANSIColors is only needed on Windows.
-func enableANSIColors() {}
+// enableLegacyWindowsANSI is only needed on Windows.
+func enableLegacyWindowsANSI() {}

--- a/ansi_windows.go
+++ b/ansi_windows.go
@@ -4,18 +4,23 @@ package lipgloss
 
 import (
 	"os"
+	"sync"
 
 	"golang.org/x/sys/windows"
 )
+
+var enableANSI sync.Once
 
 // enableANSIColors enables support for ANSI color sequences in the Windows
 // default console (cmd.exe and the PowerShell application). Note that this
 // only works with Windows 10. Also note that Windows Terminal supports colors
 // by default.
-func enableANSIColors() {
-	stdout := windows.Handle(os.Stdout.Fd())
-	var originalMode uint32
+func enableLegacyWindowsANSI() {
+	enableANSI.Do(func() {
+		stdout := windows.Handle(os.Stdout.Fd())
+		var originalMode uint32
 
-	windows.GetConsoleMode(stdout, &originalMode)
-	windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		windows.GetConsoleMode(stdout, &originalMode)
+		windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+	})
 }

--- a/ansi_windows.go
+++ b/ansi_windows.go
@@ -1,0 +1,21 @@
+// +build windows
+
+package lipgloss
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// enableANSIColors enables support for ANSI color sequences in the Windows
+// default console (cmd.exe and the PowerShell application). Note that this
+// only works with Windows 10. Also note that Windows Terminal supports colors
+// by default.
+func enableANSIColors() {
+	stdout := windows.Handle(os.Stdout.Fd())
+	var originalMode uint32
+
+	windows.GetConsoleMode(stdout, &originalMode)
+	windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+}

--- a/color.go
+++ b/color.go
@@ -18,6 +18,7 @@ var (
 // actual check only once.
 func ColorProfile() termenv.Profile {
 	getColorProfile.Do(func() {
+		enableANSIColors()
 		colorProfile = termenv.ColorProfile()
 	})
 	return colorProfile

--- a/color.go
+++ b/color.go
@@ -18,7 +18,6 @@ var (
 // actual check only once.
 func ColorProfile() termenv.Profile {
 	getColorProfile.Do(func() {
-		enableANSIColors()
 		colorProfile = termenv.ColorProfile()
 	})
 	return colorProfile

--- a/style.go
+++ b/style.go
@@ -190,6 +190,10 @@ func (s Style) Render(str string) string {
 		useSpaceStyler = underlineSpaces || strikethroughSpaces
 	)
 
+	// Enable support for ANSI on the legacy Windows cmd.exe console. This is a
+	// no-op on non-Windows systems and on Windows runs only once.
+	enableLegacyWindowsANSI()
+
 	if bold {
 		te = te.Bold()
 	}


### PR DESCRIPTION
This PR includes support for the Windows 10 legacy command console, which includes cmd.exe and the standalone PowerShell application on Windows. Lip Gloss should now "just work" on those consoles.

Note that this update isn't needed in [Windows Terminal](https://github.com/microsoft/terminal).