### PR TITLE
Border Color API Consistency

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -103,15 +103,15 @@ func (s Style) applyBorder(str string) string {
 		hasBottom = s.getAsBool(borderBottomKey, false)
 		hasLeft   = s.getAsBool(borderLeftKey, false)
 
-		topFGColor    = s.getAsColor(borderTopFGColorKey)
-		rightFGColor  = s.getAsColor(borderRightFGColorKey)
-		bottomFGColor = s.getAsColor(borderBottomFGColorKey)
-		leftFGColor   = s.getAsColor(borderLeftFGColorKey)
+		topFG    = s.getAsColor(borderTopForegroundKey)
+		rightFG  = s.getAsColor(borderRightForegroundKey)
+		bottomFG = s.getAsColor(borderBottomForegroundKey)
+		leftFG   = s.getAsColor(borderLeftForegroundKey)
 
-		topBGColor    = s.getAsColor(borderTopBGColorKey)
-		rightBGColor  = s.getAsColor(borderRightBGColorKey)
-		bottomBGColor = s.getAsColor(borderBottomBGColorKey)
-		leftBGColor   = s.getAsColor(borderLeftBGColorKey)
+		topBG    = s.getAsColor(borderTopBackgroundKey)
+		rightBG  = s.getAsColor(borderRightBackgroundKey)
+		bottomBG = s.getAsColor(borderBottomBackgroundKey)
+		leftBG   = s.getAsColor(borderLeftBackgroundKey)
 	)
 
 	// If a border is set and no sides have been specifically turned on or off
@@ -164,7 +164,7 @@ func (s Style) applyBorder(str string) string {
 	// Render top
 	if hasTop {
 		top := renderHorizontalEdge(border.TopLeft, border.Top, border.TopRight, width)
-		top = styleBorder(top, topFGColor, topBGColor)
+		top = styleBorder(top, topFG, topBG)
 		out.WriteString(top)
 		out.WriteRune('\n')
 	}
@@ -172,11 +172,11 @@ func (s Style) applyBorder(str string) string {
 	// Render sides
 	for i, l := range lines {
 		if hasLeft {
-			out.WriteString(styleBorder(border.Left, leftFGColor, leftBGColor))
+			out.WriteString(styleBorder(border.Left, leftFG, leftBG))
 		}
 		out.WriteString(l)
 		if hasRight {
-			out.WriteString(styleBorder(border.Right, rightFGColor, rightBGColor))
+			out.WriteString(styleBorder(border.Right, rightFG, rightBG))
 		}
 		if i < len(lines)-1 {
 			out.WriteRune('\n')
@@ -186,7 +186,7 @@ func (s Style) applyBorder(str string) string {
 	// Render bottom
 	if hasBottom {
 		bottom := renderHorizontalEdge(border.BottomLeft, border.Bottom, border.BottomRight, width)
-		bottom = styleBorder(bottom, bottomFGColor, bottomBGColor)
+		bottom = styleBorder(bottom, bottomFG, bottomBG)
 		out.WriteRune('\n')
 		out.WriteString(bottom)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -63,7 +63,7 @@ var (
 
 	tab = lipgloss.NewStyle().
 		Border(tabBorder, true).
-		BorderForegroundColor(highlight).
+		BorderForeground(highlight).
 		Padding(0, 1)
 
 	activeTab = tab.Copy().Border(activeTabBorder, true)
@@ -88,13 +88,13 @@ var (
 	infoStyle = lipgloss.NewStyle().
 			BorderStyle(lipgloss.NormalBorder()).
 			BorderTop(true).
-			BorderForegroundColor(subtle)
+			BorderForeground(subtle)
 
 	// Dialog.
 
 	dialogBoxStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForegroundColor(lipgloss.Color("#874BFD")).
+			BorderForeground(lipgloss.Color("#874BFD")).
 			Padding(1, 0).
 			BorderTop(true).
 			BorderLeft(true).
@@ -117,7 +117,7 @@ var (
 
 	list = lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder(), false, true, false, false).
-		BorderForegroundColor(subtle).
+		BorderForeground(subtle).
 		MarginRight(2).
 		Height(8).
 		Width(columnWidth + 1)
@@ -125,7 +125,7 @@ var (
 	listHeader = lipgloss.NewStyle().
 			BorderStyle(lipgloss.NormalBorder()).
 			BorderBottom(true).
-			BorderForegroundColor(subtle).
+			BorderForeground(subtle).
 			MarginRight(2).
 			Render
 

--- a/set.go
+++ b/set.go
@@ -316,7 +316,7 @@ func (s Style) BorderLeft(v bool) Style {
 	return s
 }
 
-// BorderForegroundColor is a shorthand function for setting all of the
+// BorderForeground is a shorthand function for setting all of the
 // foreground colors of the borders at once. The arguments work as follows:
 //
 // With one argument, the argument is applied to all sides.
@@ -331,7 +331,7 @@ func (s Style) BorderLeft(v bool) Style {
 // top side, followed by the right side, then the bottom, and finally the left.
 //
 // With more than four arguments nothing will be set.
-func (s Style) BorderForegroundColor(c ...TerminalColor) Style {
+func (s Style) BorderForeground(c ...TerminalColor) Style {
 	if len(c) == 0 {
 		return s
 	}
@@ -341,35 +341,35 @@ func (s Style) BorderForegroundColor(c ...TerminalColor) Style {
 		return s
 	}
 
-	s.set(borderTopFGColorKey, top)
-	s.set(borderRightFGColorKey, right)
-	s.set(borderBottomFGColorKey, bottom)
-	s.set(borderLeftFGColorKey, left)
+	s.set(borderTopForegroundKey, top)
+	s.set(borderRightForegroundKey, right)
+	s.set(borderBottomForegroundKey, bottom)
+	s.set(borderLeftForegroundKey, left)
 
 	return s
 }
 
 // BorderTopForegroundColor set the top color of the border.
-func (s Style) BorderTopForegroundColor(c TerminalColor) Style {
-	s.set(borderTopFGColorKey, c)
+func (s Style) BorderTopForeground(c TerminalColor) Style {
+	s.set(borderTopForegroundKey, c)
 	return s
 }
 
 // BorderRightForegroundColor set the top color of the border.
-func (s Style) BorderRightForegroundColor(c TerminalColor) Style {
-	s.set(borderRightFGColorKey, c)
+func (s Style) BorderRightForeground(c TerminalColor) Style {
+	s.set(borderRightForegroundKey, c)
 	return s
 }
 
 // BorderBottomForegroundColor set the top color of the border.
-func (s Style) BorderBottomForegroundColor(c TerminalColor) Style {
-	s.set(borderBottomFGColorKey, c)
+func (s Style) BorderBottomForeground(c TerminalColor) Style {
+	s.set(borderBottomForegroundKey, c)
 	return s
 }
 
 // BorderLeftForegroundColor set the top color of the border.
-func (s Style) BorderLeftForegroundColor(c TerminalColor) Style {
-	s.set(borderLeftFGColorKey, c)
+func (s Style) BorderLeftForeground(c TerminalColor) Style {
+	s.set(borderLeftForegroundKey, c)
 	return s
 }
 
@@ -388,7 +388,7 @@ func (s Style) BorderLeftForegroundColor(c TerminalColor) Style {
 // top side, followed by the right side, then the bottom, and finally the left.
 //
 // With more than four arguments nothing will be set.
-func (s Style) BorderBackgroundColor(c ...TerminalColor) Style {
+func (s Style) BorderBackground(c ...TerminalColor) Style {
 	if len(c) == 0 {
 		return s
 	}
@@ -398,35 +398,35 @@ func (s Style) BorderBackgroundColor(c ...TerminalColor) Style {
 		return s
 	}
 
-	s.set(borderTopBGColorKey, top)
-	s.set(borderRightBGColorKey, right)
-	s.set(borderBottomBGColorKey, bottom)
-	s.set(borderLeftBGColorKey, left)
+	s.set(borderTopBackgroundKey, top)
+	s.set(borderRightBackgroundKey, right)
+	s.set(borderBottomBackgroundKey, bottom)
+	s.set(borderLeftBackgroundKey, left)
 
 	return s
 }
 
 // BorderTopBackgroundColor set the top color of the border.
-func (s Style) BorderTopBackgroundColor(c TerminalColor) Style {
-	s.set(borderTopBGColorKey, c)
+func (s Style) BorderTopBackground(c TerminalColor) Style {
+	s.set(borderTopBackgroundKey, c)
 	return s
 }
 
 // BorderRightBackgroundColor set the top color of the border.
-func (s Style) BorderRightBackgroundColor(c TerminalColor) Style {
-	s.set(borderRightBGColorKey, c)
+func (s Style) BorderRightBackground(c TerminalColor) Style {
+	s.set(borderRightBackgroundKey, c)
 	return s
 }
 
 // BorderBottomBackgroundColor set the top color of the border.
-func (s Style) BorderBottomBackgroundColor(c TerminalColor) Style {
-	s.set(borderBottomBGColorKey, c)
+func (s Style) BorderBottomBackground(c TerminalColor) Style {
+	s.set(borderBottomBackgroundKey, c)
 	return s
 }
 
 // BorderLeftBackgroundColor set the top color of the border.
-func (s Style) BorderLeftBackgroundColor(c TerminalColor) Style {
-	s.set(borderLeftBGColorKey, c)
+func (s Style) BorderLeftBackground(c TerminalColor) Style {
+	s.set(borderLeftBackgroundKey, c)
 	return s
 }
 

--- a/style.go
+++ b/style.go
@@ -52,16 +52,16 @@ const (
 	borderLeftKey
 
 	// Border foreground colors.
-	borderTopFGColorKey
-	borderRightFGColorKey
-	borderBottomFGColorKey
-	borderLeftFGColorKey
+	borderTopForegroundKey
+	borderRightForegroundKey
+	borderBottomForegroundKey
+	borderLeftForegroundKey
 
 	// Border background colors.
-	borderTopBGColorKey
-	borderRightBGColorKey
-	borderBottomBGColorKey
-	borderLeftBGColorKey
+	borderTopBackgroundKey
+	borderRightBackgroundKey
+	borderBottomBackgroundKey
+	borderLeftBackgroundKey
 
 	inlineKey
 	maxWidthKey

--- a/unset.go
+++ b/unset.go
@@ -182,86 +182,78 @@ func (s Style) UnsetBorderLeft() Style {
 	return s
 }
 
-// UnsetBorderColor removes all border foreground and background colors, if
+// UnsetBorderForeground removes all border foreground colors styles, if
 // set.
-func (s Style) UnsetBorderColor() Style {
-	s.UnsetBorderForegroundColor()
-	s.UnsetBorderBackgroundColor()
+func (s Style) UnsetBorderForeground() Style {
+	delete(s.rules, borderTopForegroundKey)
+	delete(s.rules, borderRightForegroundKey)
+	delete(s.rules, borderBottomForegroundKey)
+	delete(s.rules, borderLeftForegroundKey)
 	return s
 }
 
-// UnsetBorderForegroundColor removes all border foreground colors styles, if
-// set.
-func (s Style) UnsetBorderForegroundColor() Style {
-	delete(s.rules, borderTopFGColorKey)
-	delete(s.rules, borderRightFGColorKey)
-	delete(s.rules, borderBottomFGColorKey)
-	delete(s.rules, borderLeftFGColorKey)
-	return s
-}
-
-// UnsetBorderTopForegroundColor removes the top border foreground color rule,
+// UnsetBorderTopForeground removes the top border foreground color rule,
 // if set.
-func (s Style) UnsetBorderTopForegroundColor() Style {
-	delete(s.rules, borderTopFGColorKey)
+func (s Style) UnsetBorderTopForeground() Style {
+	delete(s.rules, borderTopForegroundKey)
 	return s
 }
 
-// UnsetBorderRightForegroundColor removes the right border foreground color rule,
+// UnsetBorderRightForeground removes the right border foreground color rule,
 // if set.
-func (s Style) UnsetBorderRightForegroundColor() Style {
-	delete(s.rules, borderRightFGColorKey)
+func (s Style) UnsetBorderRightForeground() Style {
+	delete(s.rules, borderRightForegroundKey)
 	return s
 }
 
-// UnsetBorderBottomForegroundColor removes the bottom border foreground color
+// UnsetBorderBottomForeground removes the bottom border foreground color
 // rule, if set.
-func (s Style) UnsetBorderBottomForegroundColor() Style {
-	delete(s.rules, borderBottomFGColorKey)
+func (s Style) UnsetBorderBottomForeground() Style {
+	delete(s.rules, borderBottomForegroundKey)
 	return s
 }
 
-// UnsetBorderLeftForegroundColor removes the left border foreground color rule,
+// UnsetBorderLeftForeground removes the left border foreground color rule,
 // if set.
-func (s Style) UnsetBorderLeftForegroundColor() Style {
-	delete(s.rules, borderLeftFGColorKey)
+func (s Style) UnsetBorderLeftForeground() Style {
+	delete(s.rules, borderLeftForegroundKey)
 	return s
 }
 
-// UnsetBorderBackgroundColor removes all border background color styles, if
+// UnsetBorderBackground removes all border background color styles, if
 // set.
-func (s Style) UnsetBorderBackgroundColor() Style {
-	delete(s.rules, borderTopBGColorKey)
-	delete(s.rules, borderRightBGColorKey)
-	delete(s.rules, borderBottomBGColorKey)
-	delete(s.rules, borderLeftBGColorKey)
+func (s Style) UnsetBorderBackground() Style {
+	delete(s.rules, borderTopBackgroundKey)
+	delete(s.rules, borderRightBackgroundKey)
+	delete(s.rules, borderBottomBackgroundKey)
+	delete(s.rules, borderLeftBackgroundKey)
 	return s
 }
 
-// UnsetBorderTopBackgroundColor removes the top border background color rule,
+// UnsetBorderTopBackground removes the top border background color rule,
 // if set.
 func (s Style) UnsetBorderTopBackgroundColor() Style {
-	delete(s.rules, borderTopBGColorKey)
+	delete(s.rules, borderTopBackgroundKey)
 	return s
 }
 
-// UnsetBorderRightBackgroundColor removes the right border background color
+// UnsetBorderRightBackground removes the right border background color
 // rule, if set.
-func (s Style) UnsetBorderRightBackgroundColor() Style {
-	delete(s.rules, borderRightBGColorKey)
+func (s Style) UnsetBorderRightBackground() Style {
+	delete(s.rules, borderRightBackgroundKey)
 	return s
 }
 
-// UnsetBorderBottomBackgroundColor removes the bottom border background color
+// UnsetBorderBottomBackground removes the bottom border background color
 // rule, if set.
-func (s Style) UnsetBorderBottomBackgroundColor() Style {
-	delete(s.rules, borderBottomBGColorKey)
+func (s Style) UnsetBorderBottomBackground() Style {
+	delete(s.rules, borderBottomBackgroundKey)
 	return s
 }
 
-// UnsetBorderLeftBackgroundColor removes the left border color rule, if set.
-func (s Style) UnsetBorderLeftBackgroundColor() Style {
-	delete(s.rules, borderLeftBGColorKey)
+// UnsetBorderLeftBackground removes the left border color rule, if set.
+func (s Style) UnsetBorderLeftBackground() Style {
+	delete(s.rules, borderLeftBackgroundKey)
 	return s
 }
 

--- a/unset.go
+++ b/unset.go
@@ -144,9 +144,9 @@ func (s Style) UnsetMarginBottom() Style {
 	return s
 }
 
-// UnsetMarginBackground removes the margin's background color. The margin's
-// background color is set from the background color of another style during
-// inheritance.
+// UnsetMarginBackground removes the margin's background color. Note that the
+// margin's background color can be set from the background color of another
+// style during inheritance.
 func (s Style) UnsetMarginBackground() Style {
 	delete(s.rules, marginBackgroundKey)
 	return s
@@ -182,8 +182,7 @@ func (s Style) UnsetBorderLeft() Style {
 	return s
 }
 
-// UnsetBorderForeground removes all border foreground colors styles, if
-// set.
+// UnsetBorderForeground removes all border foreground color styles, if set.
 func (s Style) UnsetBorderForeground() Style {
 	delete(s.rules, borderTopForegroundKey)
 	delete(s.rules, borderRightForegroundKey)


### PR DESCRIPTION
This PR drops the _Color_ suffixes from the foreground and background portions of the border API so that the border API better matches the rest of the API. For example, `BorderTopForegroundColor` is now simply `BorderTopForeground`.

Additionally, `UnsetBorderColor` has been removed. To unset border colors use `UnsetBorderForeground` and `UnsetBorderBackground`.