### PR TITLE
Keep margins, padding, widths, and heights positive

### DIFF
--- a/set.go
+++ b/set.go
@@ -93,7 +93,7 @@ func (s Style) Background(c TerminalColor) Style {
 // Width sets the width of the block before applying margins. The width, if
 // set, also determines where text will wrap.
 func (s Style) Width(i int) Style {
-	s.set(widthKey, i)
+	s.set(widthKey, max(0, i))
 	return s
 }
 
@@ -101,7 +101,7 @@ func (s Style) Width(i int) Style {
 // the text block is less than this value after applying padding (or not), the
 // block will be set to this height.
 func (s Style) Height(i int) Style {
-	s.set(heightKey, i)
+	s.set(heightKey, max(0, i))
 	return s
 }
 
@@ -131,34 +131,34 @@ func (s Style) Padding(i ...int) Style {
 		return s
 	}
 
-	s.set(paddingTopKey, top)
-	s.set(paddingRightKey, right)
-	s.set(paddingBottomKey, bottom)
-	s.set(paddingLeftKey, left)
+	s.set(paddingTopKey, max(0, top))
+	s.set(paddingRightKey, max(0, right))
+	s.set(paddingBottomKey, max(0, bottom))
+	s.set(paddingLeftKey, max(0, left))
 	return s
 }
 
 // PaddingLeft adds padding on the left.
 func (s Style) PaddingLeft(i int) Style {
-	s.set(paddingLeftKey, i)
+	s.set(paddingLeftKey, max(0, i))
 	return s
 }
 
 // PaddingRight adds padding on the right.
 func (s Style) PaddingRight(i int) Style {
-	s.set(paddingRightKey, i)
+	s.set(paddingRightKey, max(0, i))
 	return s
 }
 
 // PaddingTop adds padding to the top of the block.
 func (s Style) PaddingTop(i int) Style {
-	s.set(paddingTopKey, i)
+	s.set(paddingTopKey, max(0, i))
 	return s
 }
 
 // PaddingBottom adds padding to the bottom of the block.
 func (s Style) PaddingBottom(i int) Style {
-	s.set(paddingBottomKey, i)
+	s.set(paddingBottomKey, max(0, i))
 	return s
 }
 
@@ -191,34 +191,34 @@ func (s Style) Margin(i ...int) Style {
 		return s
 	}
 
-	s.set(marginTopKey, top)
-	s.set(marginRightKey, right)
-	s.set(marginBottomKey, bottom)
-	s.set(marginLeftKey, left)
+	s.set(marginTopKey, max(0, top))
+	s.set(marginRightKey, max(0, right))
+	s.set(marginBottomKey, max(0, bottom))
+	s.set(marginLeftKey, max(0, left))
 	return s
 }
 
 // MarginLeft sets the value of the left margin.
 func (s Style) MarginLeft(i int) Style {
-	s.set(marginLeftKey, i)
+	s.set(marginLeftKey, max(0, i))
 	return s
 }
 
 // MarginRight sets the value of the right margin.
 func (s Style) MarginRight(i int) Style {
-	s.set(marginRightKey, i)
+	s.set(marginRightKey, max(0, i))
 	return s
 }
 
 // MarginTop sets the value of the top margin.
 func (s Style) MarginTop(i int) Style {
-	s.set(marginTopKey, i)
+	s.set(marginTopKey, max(0, i))
 	return s
 }
 
 // MarginBottom sets the value of the bottom margin.
 func (s Style) MarginBottom(i int) Style {
-	s.set(marginBottomKey, i)
+	s.set(marginBottomKey, max(0, i))
 	return s
 }
 
@@ -465,7 +465,7 @@ func (s Style) Inline(v bool) Style {
 //
 func (s Style) MaxWidth(n int) Style {
 	o := s.Copy()
-	o.set(maxWidthKey, n)
+	o.set(maxWidthKey, max(0, n))
 	return o
 }
 
@@ -477,7 +477,7 @@ func (s Style) MaxWidth(n int) Style {
 // not mutate the style and instead return a copy.
 func (s Style) MaxHeight(n int) Style {
 	o := s.Copy()
-	o.set(maxHeightKey, n)
+	o.set(maxHeightKey, max(0, n))
 	return o
 }
 


### PR DESCRIPTION
And the moment, Lip Gloss only supports positive values in sizing operations. This PR sets values to `0` in the following methods for all arguments below `0`:

* `Width`
* `Height`
* `MaxWidth`
* `MaxHeight`
* `Padding`
* `PaddingTop`
* `PaddingRight`
* `PaddingBottom`
* `PaddingLeft`
* `MarginTop`
* `MarginRight`
* `MarginBottom`
* `MarginLeft`

A note on types: internally we use `int`s as it's Go's default type of integer and makes working with functions like `len` a bit easier. This could be an argument for using `uint` internally.