### PR TITLE
Query terminal background color on init

### DIFF
--- a/color.go
+++ b/color.go
@@ -8,10 +8,13 @@ import (
 )
 
 var (
-	colorProfile        termenv.Profile
-	getColorProfile     sync.Once
-	hasDarkBackground   bool
-	checkDarkBackground sync.Once
+	colorProfile    termenv.Profile
+	getColorProfile sync.Once
+
+	// Because it's a potentially long operation (relatively speaking), we
+	// check the background color on initialization rather than at the last
+	// possible second.
+	hasDarkBackground = termenv.HasDarkBackground()
 )
 
 // ColorProfile returns the detected termenv color profile. It will perform the
@@ -24,11 +27,7 @@ func ColorProfile() termenv.Profile {
 }
 
 // HadDarkBackground returns whether or not the terminal has a dark background.
-// It will perform the actual check only once.
 func HasDarkBackground() bool {
-	checkDarkBackground.Do(func() {
-		hasDarkBackground = termenv.HasDarkBackground()
-	})
 	return hasDarkBackground
 }
 

--- a/unset.go
+++ b/unset.go
@@ -144,9 +144,9 @@ func (s Style) UnsetMarginBottom() Style {
 	return s
 }
 
-// UnsetMarginBackground removes the margin's background color. The margin's
-// background color is set from the background color of another style during
-// inheritance.
+// UnsetMarginBackground removes the margin's background color. Note that the
+// margin's background color can be set from the background color of another
+// style during inheritance.
 func (s Style) UnsetMarginBackground() Style {
 	delete(s.rules, marginBackgroundKey)
 	return s
@@ -182,8 +182,7 @@ func (s Style) UnsetBorderLeft() Style {
 	return s
 }
 
-// UnsetBorderForeground removes all border foreground colors styles, if
-// set.
+// UnsetBorderForeground removes all border foreground color styles, if set.
 func (s Style) UnsetBorderForeground() Style {
 	delete(s.rules, borderTopForegroundKey)
 	delete(s.rules, borderRightForegroundKey)


### PR DESCRIPTION
This PR queries the terminal background color on package initialization, avoiding potential race conditions (and lag) that could occur previously when it was queried only when first needed, which had a very high likelihood of happening during a render.

See charmbracelet/bubbletea#86, where this issue was discovered.