### PR TITLE
Quince is not a citrus fruit

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -267,7 +267,7 @@ func main() {
 		list.Render(
 			lipgloss.JoinVertical(lipgloss.Left,
 				listHeader("Citrus Fruits to Try"),
-				listDone("Quince"),
+				listDone("Grapefruit"),
 				listDone("Yuzu"),
 				listItem("Citron"),
 				listItem("Kumquat"),


### PR DESCRIPTION
A correction in the example, as noted in the Fediverse: https://cathode.church/@meena/106002336386354738