### PR TITLE
Borders, sizing, and an emoji-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,29 @@ lipgloss.HorizontalJoin(0.2, paragraphA, paragraphB, paragraphC)
 ```
 
 
+### Measuring Width and Height
+
+Sometimes you’ll want to know the width and height of text blocks when building
+your layouts:
+
+```go
+var block string = lipgloss.NewStyle().
+    Width(40).
+    Padding(2).
+    Render(someLongString)
+
+// Get the actual, phsical dimensions of the text block.
+width := lipgloss.Width(block)
+height := lipgloss.Height(block)
+
+// Here's a shorthand function.
+w, h := lipgloss.Size(block)
+```
+
+
 ### Placing Text in Whitespace
 
-Sometimes you simply want to place a block of text in whitespace.
+Sometimes you’ll simply want to place a block of text in whitespace.
 
 ```go
 // Center a paragraph horizontally in a space 80 cells wide. The height of

--- a/README.md
+++ b/README.md
@@ -157,6 +157,52 @@ var str = lipgloss.NewStyle().
 ```
 
 
+## Borders
+
+You can add borders to things, too:
+
+```go
+// Add a purple, regtangular border
+var style = lipgloss.NewStyle().
+    BorderStyle(lipgloss.NormalBorder()).
+    BorderForeground(lipgloss.Color("#7D56F4"))
+
+// Add a rounded, yellow-on-purple border to the top and left
+var anotherStyle = lipgloss.NewStyle().
+    BorderStyle(lipgloss.RoundedBorder()).
+    BorderForeground(lipgloss.Color("#FFF738")).
+    BorderBackground(lipgloss.Color("#7D56F4")).
+    BorderTop(true).
+    BorderLeft(true)
+
+// Make your own border
+var myCuteBorder = lipgloss.Border{
+    Top:         "._.:*:._",
+    Bottom:      "._.:*:._",
+    Left:        "|",
+    Right:       "|",
+    TopLeft:     "+",
+    TopRight:    "+",
+    BottomLeft:  "+",
+    BottomRight: "+",
+}
+```
+
+There are also shorthand functions, which follow a similar pattern to the
+margin and padding shorthand functions.
+
+```go
+// Add a thick border to the top and bottom
+lipgloss.NewStyle().Border(lipgloss.ThickBorder(), true, false)
+
+// Add a thick border to the right and bottom sides. Rules are set clockwise
+// from top.
+lipgloss.NewStyle().Border(lipgloss.DoubleBorder(), true, false, false, true)
+```
+
+For more on borders see [the docs][docs].
+
+
 ## Copying Styles
 
 Just use `Copy()`:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var style = lipgloss.NewStyle().
     PaddingLeft(4).
     Width(22)
 
-    fmt.Println(style.Render("Hello, kitty."))
+fmt.Println(style.Render("Hello, kitty."))
 ```
 
 
@@ -159,19 +159,19 @@ var str = lipgloss.NewStyle().
 
 ## Borders
 
-You can add borders to things, too:
+Adding borders is easy:
 
 ```go
 // Add a purple, regtangular border
 var style = lipgloss.NewStyle().
     BorderStyle(lipgloss.NormalBorder()).
-    BorderForeground(lipgloss.Color("#7D56F4"))
+    BorderForeground(lipgloss.Color("63"))
 
-// Add a rounded, yellow-on-purple border to the top and left
+// Set a rounded, yellow-on-purple border to the top and left
 var anotherStyle = lipgloss.NewStyle().
     BorderStyle(lipgloss.RoundedBorder()).
-    BorderForeground(lipgloss.Color("#FFF738")).
-    BorderBackground(lipgloss.Color("#7D56F4")).
+    BorderForeground(lipgloss.Color("228")).
+    BorderBackground(lipgloss.Color("63")).
     BorderTop(true).
     BorderLeft(true)
 
@@ -188,16 +188,18 @@ var myCuteBorder = lipgloss.Border{
 }
 ```
 
-There are also shorthand functions, which follow a similar pattern to the
-margin and padding shorthand functions.
+There are also shorthand functions for defining borders, which follow a similar
+pattern to the margin and padding shorthand functions.
 
 ```go
 // Add a thick border to the top and bottom
-lipgloss.NewStyle().Border(lipgloss.ThickBorder(), true, false)
+lipgloss.NewStyle().
+    Border(lipgloss.ThickBorder(), true, false)
 
 // Add a thick border to the right and bottom sides. Rules are set clockwise
 // from top.
-lipgloss.NewStyle().Border(lipgloss.DoubleBorder(), true, false, false, true)
+lipgloss.NewStyle().
+    Border(lipgloss.DoubleBorder(), true, false, false, true)
 ```
 
 For more on borders see [the docs][docs].
@@ -284,15 +286,16 @@ var style = lipgloss.NewStyle().String("你好，猫咪。").Bold(true)
 fmt.Printf("%s\n", style)
 ```
 
+
 ## Utilities
 
-In addition to pure styling Lip Gloss also ships with some layout utilties.
+In addition to pure styling, Lip Gloss also ships with some utilties to help
+assemble your layouts.
 
 
 ### Joining Paragraphs
 
-There are also some utility functions for horizontally and vertically joining
-paragraphs of text.
+Horizontally and vertically joining paragraphs is a cinch.
 
 ```go
 // Horizontally join three paragraphs along their bottom edges
@@ -310,7 +313,7 @@ lipgloss.HorizontalJoin(0.2, paragraphA, paragraphB, paragraphC)
 ### Measuring Width and Height
 
 Sometimes you’ll want to know the width and height of text blocks when building
-your layouts:
+your layouts.
 
 ```go
 var block string = lipgloss.NewStyle().

--- a/README.md
+++ b/README.md
@@ -177,14 +177,14 @@ var anotherStyle = lipgloss.NewStyle().
 
 // Make your own border
 var myCuteBorder = lipgloss.Border{
-    Top:         "._.:*:._",
-    Bottom:      "._.:*:._",
-    Left:        "|",
-    Right:       "|",
-    TopLeft:     "+",
-    TopRight:    "+",
-    BottomLeft:  "+",
-    BottomRight: "+",
+    Top:         "._.:*:",
+    Bottom:      "._.:*:",
+    Left:        "|*",
+    Right:       "|*",
+    TopLeft:     "*",
+    TopRight:    "*",
+    BottomLeft:  "*",
+    BottomRight: "*",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -238,8 +238,12 @@ var style = lipgloss.NewStyle().String("你好，猫咪。").Bold(true)
 fmt.Printf("%s\n", style)
 ```
 
+## Utilities
 
-## Joining Paragraphs
+In addition to pure styling Lip Gloss also ships with some layout utilties.
+
+
+### Joining Paragraphs
 
 There are also some utility functions for horizontally and vertically joining
 paragraphs of text.
@@ -257,7 +261,7 @@ lipgloss.HorizontalJoin(0.2, paragraphA, paragraphB, paragraphC)
 ```
 
 
-## Placing Text in Whitespace
+### Placing Text in Whitespace
 
 Sometimes you simply want to place a block of text in whitespace.
 
@@ -275,6 +279,7 @@ block := lipgloss.Place(30, 80, lipgloss.Right, lipgloss.Bottom, fancyStyledPara
 ```
 
 You can also style the whitespace. For details, see [the docs][docs].
+
 
 ***
 

--- a/borders.go
+++ b/borders.go
@@ -182,6 +182,12 @@ func (s Style) applyBorder(str string) string {
 		}
 	}
 
+	// For now, limit corners to one rune.
+	border.TopLeft = getFirstRuneAsString(border.TopLeft)
+	border.TopRight = getFirstRuneAsString(border.TopRight)
+	border.BottomRight = getFirstRuneAsString(border.BottomRight)
+	border.BottomLeft = getFirstRuneAsString(border.BottomLeft)
+
 	var out strings.Builder
 
 	// Render top
@@ -290,4 +296,12 @@ func maxRuneWidth(str string) (width int) {
 		}
 	}
 	return width
+}
+
+func getFirstRuneAsString(str string) string {
+	if str == "" {
+		return str
+	}
+	r := []rune(str)
+	return string(r[0])
 }

--- a/example/go.sum
+++ b/example/go.sum
@@ -2,8 +2,9 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
+github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 h1:y1p/ycavWjGT9FnmSjdbWUlLGvcxrY0Rw3ATltrxOhk=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIWdQqJzsxyjgl3P22oYZnHdZ8FFTHAQQt5BMQ=
 github.com/muesli/termenv v0.8.1 h1:9q230czSP3DHVpkaPDXGp0TOfAwyjyYwXlUCQxQSaBk=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.15
 
 require (
 	github.com/lucasb-eyer/go-colorful v1.2.0
+	github.com/mattn/go-runewidth v0.0.12
 	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68
 	github.com/muesli/termenv v0.8.1
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,9 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
+github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 h1:y1p/ycavWjGT9FnmSjdbWUlLGvcxrY0Rw3ATltrxOhk=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIWdQqJzsxyjgl3P22oYZnHdZ8FFTHAQQt5BMQ=
 github.com/muesli/termenv v0.8.1 h1:9q230czSP3DHVpkaPDXGp0TOfAwyjyYwXlUCQxQSaBk=

--- a/size.go
+++ b/size.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Width returns the cell width of characters in the string. ANSI sequences are
-// ignored and characters wider than one cell (such as Chinese characters) are
-// appropriately measured.
+// ignored and characters wider than one cell (such as Chinese characters and
+// emojis) are appropriately measured.
 //
 // You should use this instead of len(string) len([]rune(string) as neither
 // will give you accurate results.
@@ -29,4 +29,13 @@ func Width(str string) (width int) {
 // height.
 func Height(str string) int {
 	return strings.Count(str, "\n") + 1
+}
+
+// Size returns the width and height of the string in cells. ANSI sequences are
+// ignored and characters wider than one cell (such as Chinese characters and
+// emojis) are appropriately measured.
+func Size(str string) (width, height int) {
+	width = Width(str)
+	height = Height(str)
+	return width, height
 }


### PR DESCRIPTION
This PR adds support for fancier borders, fixes some bugs, adds a helper function for measuring text block sizes, and improves the README.

With the new border support, it's possible to construct borders from multiple runes, such as this:

<img width="738" alt="A Rococo-style borer constructed of multiple runes" src="https://user-images.githubusercontent.com/25087/116488184-b9f2f900-a85f-11eb-9ba6-c08ac0ae9169.png">

## New

* Support for multi-rune borders
* Added `Size() (int, int)` for returning the width and the height of a block in one go

## Fixed

* Bump go-runewidth to fix some emoji mis-measuring
* Fix a panic that could happen in custom borders