### PR TITLE
Add SetColorProfile for explicitly setting the color profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ lipgloss.Color("201") // hot pink
 lipgloss.Color("202") // orange
 ```
 
-### True Color (24-bit)
+### True Color (16,777,216 colors; 24-bit)
 
 ```go
 lipgloss.Color("#0000FF") // good ol' 100% blue
 lipgloss.Color("#04B575") // a green
 lipgloss.Color("#3C3C3C") // a dark gray
 ```
+
+...as well as a 1-bit Ascii profile, which is black and white only.
 
 The terminal's color profile will be automatically detected, and colors outside
 the gamut of the current palette will be automatically coerced to their closest

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,53 @@
+package lipgloss
+
+import (
+	"testing"
+
+	"github.com/muesli/termenv"
+)
+
+func TestSetColorProfile(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		profile  termenv.Profile
+		input    string
+		style    Style
+		expected string
+	}{
+		{
+			termenv.Ascii,
+			"hello",
+			NewStyle().Foreground(Color("#5A56E0")),
+			"hello",
+		},
+		{
+			termenv.ANSI,
+			"hello",
+			NewStyle().Foreground(Color("#5A56E0")),
+			"\x1b[34mhello\x1b[0m",
+		},
+		{
+			termenv.ANSI256,
+			"hello",
+			NewStyle().Foreground(Color("#5A56E0")),
+			"\x1b[38;5;62mhello\x1b[0m",
+		},
+		{
+			termenv.TrueColor,
+			"hello",
+			NewStyle().Foreground(Color("#5A56E0")),
+			"\x1b[38;2;89;86;224mhello\x1b[0m",
+		},
+	}
+
+	for i, tc := range tt {
+		SetColorProfile(tc.profile)
+		res := tc.style.Render(tc.input)
+		if res != tc.expected {
+			t.Errorf("Test %d, expected:\n\n`%s`\n`%s`\n\nActual output:\n\n`%s`\n`%s`\n\n",
+				i, tc.expected, formatEscapes(tc.expected),
+				res, formatEscapes(res))
+		}
+	}
+}

--- a/runes_test.go
+++ b/runes_test.go
@@ -58,13 +58,5 @@ func TestStyleRunes(t *testing.T) {
 }
 
 func formatEscapes(str string) string {
-	var b strings.Builder
-	for _, r := range str {
-		if r == '\x1b' {
-			b.WriteString("\\x1b")
-			continue
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
+	return strings.ReplaceAll(str, "\x1b", "\\x1b")
 }


### PR DESCRIPTION
This PR allows the color profile to be set on a package-wide basis via `lipgloss.SetColorProfile`. This is mostly intended for testing purposes. By default, Lip Gloss will use the best available color profile, which is want you will want to use in your terminal applications.

Available color profiles are:

* `termenv.Ascii`: black and white (1-bit)
* `termenv.ANSI`: 16 colors (4-bit)
* `termenv.ANSI256`: 256 colors, (8-bit)
* `termenv.TrueColor`: 16,777,216 colors (24-bit)

The `SetColorProfile` method is thread-safe.

Closes #33.