### PR TITLE
Whitespace and Border Measurement

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -21,6 +21,44 @@ type Border struct {
 	BottomLeft  string
 }
 
+// GetTopWidth returns the width of the top border. If borders contain runes of
+// varying widths, the widest rune is returned. If no border exists on the top
+// edge, 0 is returned.
+func (b Border) GetTopWidth() int {
+	return getBorderEdgeWidth(b.TopLeft, b.Top, b.TopRight)
+}
+
+// GetRightWidth returns the width of the right border. If borders contain
+// runes of varying widths, the widest rune is returned. If no border exists on
+// the right edge, 0 is returned.
+func (b Border) GetRightWidth() int {
+	return getBorderEdgeWidth(b.TopRight, b.Top, b.BottomRight)
+}
+
+// GetBottomWidth returns the width of the bottom border. If borders contain
+// runes of varying widths, the widest rune is returned. If no border exists on
+// the bottom edge, 0 is returned.
+func (b Border) GetBottomWidth() int {
+	return getBorderEdgeWidth(b.BottomLeft, b.Bottom, b.BottomRight)
+}
+
+// GetLeftWidth returns the width of the left border. If borders contain runes
+// of varying widths, the widest rune is returned. If no border exists on the
+// left edge, 0 is returned.
+func (b Border) GetLeftWidth() int {
+	return getBorderEdgeWidth(b.TopLeft, b.Left, b.TopRight)
+}
+
+func getBorderEdgeWidth(borderParts ...string) (maxWidth int) {
+	for _, piece := range borderParts {
+		w := maxRuneWidth(piece)
+		if w > maxWidth {
+			maxWidth = w
+		}
+	}
+	return maxWidth
+}
+
 var (
 	noBorder = Border{}
 

--- a/borders.go
+++ b/borders.go
@@ -21,31 +21,31 @@ type Border struct {
 	BottomLeft  string
 }
 
-// GetTopWidth returns the width of the top border. If borders contain runes of
+// GetTopSize returns the width of the top border. If borders contain runes of
 // varying widths, the widest rune is returned. If no border exists on the top
 // edge, 0 is returned.
-func (b Border) GetTopWidth() int {
+func (b Border) GetTopSize() int {
 	return getBorderEdgeWidth(b.TopLeft, b.Top, b.TopRight)
 }
 
-// GetRightWidth returns the width of the right border. If borders contain
+// GetRightSize returns the width of the right border. If borders contain
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the right edge, 0 is returned.
-func (b Border) GetRightWidth() int {
+func (b Border) GetRightSize() int {
 	return getBorderEdgeWidth(b.TopRight, b.Top, b.BottomRight)
 }
 
-// GetBottomWidth returns the width of the bottom border. If borders contain
+// GetBottomSize returns the width of the bottom border. If borders contain
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the bottom edge, 0 is returned.
-func (b Border) GetBottomWidth() int {
+func (b Border) GetBottomSize() int {
 	return getBorderEdgeWidth(b.BottomLeft, b.Bottom, b.BottomRight)
 }
 
-// GetLeftWidth returns the width of the left border. If borders contain runes
+// GetLeftSize returns the width of the left border. If borders contain runes
 // of varying widths, the widest rune is returned. If no border exists on the
 // left edge, 0 is returned.
-func (b Border) GetLeftWidth() int {
+func (b Border) GetLeftSize() int {
 	return getBorderEdgeWidth(b.TopLeft, b.Left, b.TopRight)
 }
 

--- a/borders.go
+++ b/borders.go
@@ -136,7 +136,7 @@ func (s Style) applyBorder(str string) string {
 		bottomSet = s.isSet(borderBottomKey)
 		leftSet   = s.isSet(borderLeftKey)
 
-		border    = s.getAsBorderStyle(borderStyleKey)
+		border    = s.getBorderStyle()
 		hasTop    = s.getAsBool(borderTopKey, false)
 		hasRight  = s.getAsBool(borderRightKey, false)
 		hasBottom = s.getAsBool(borderBottomKey, false)

--- a/get.go
+++ b/get.go
@@ -271,6 +271,9 @@ func (s Style) GetBorderLeftBackground() TerminalColor {
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the top edge, 0 is returned.
 func (s Style) GetBorderTopWidth() int {
+	if !s.getAsBool(borderTopKey, false) {
+		return 0
+	}
 	return s.getBorderStyle().GetTopWidth()
 }
 
@@ -278,6 +281,9 @@ func (s Style) GetBorderTopWidth() int {
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the left edge, 0 is returned.
 func (s Style) GetBorderLeftWidth() int {
+	if !s.getAsBool(borderLeftKey, false) {
+		return 0
+	}
 	return s.getBorderStyle().GetLeftWidth()
 }
 
@@ -285,6 +291,9 @@ func (s Style) GetBorderLeftWidth() int {
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the left edge, 0 is returned.
 func (s Style) GetBorderBottomWidth() int {
+	if !s.getAsBool(borderBottomKey, false) {
+		return 0
+	}
 	return s.getBorderStyle().GetBottomWidth()
 }
 
@@ -292,6 +301,9 @@ func (s Style) GetBorderBottomWidth() int {
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the right edge, 0 is returned.
 func (s Style) GetBorderRightWidth() int {
+	if !s.getAsBool(borderRightKey, false) {
+		return 0
+	}
 	return s.getBorderStyle().GetBottomWidth()
 }
 

--- a/get.go
+++ b/get.go
@@ -123,7 +123,7 @@ func (s Style) GetHorizontalPadding() int {
 // GetVerticalPadding returns the style's top and bottom padding. Unset values
 // are measured as 0.
 func (s Style) GetVerticalPadding() int {
-	return s.getAsInt(paddingLeftKey) + s.getAsInt(paddingRightKey)
+	return s.getAsInt(paddingTopKey) + s.getAsInt(paddingBottomKey)
 }
 
 // GetColorWhitespace returns the style's whitespace coloring setting. If no
@@ -274,53 +274,53 @@ func (s Style) GetBorderTopWidth() int {
 	if !s.getAsBool(borderTopKey, false) {
 		return 0
 	}
-	return s.getBorderStyle().GetTopWidth()
+	return s.getBorderStyle().GetTopSize()
 }
 
-// GetBorderLeftWidth returns the width of the left border. If borders contain
+// GetBorderLeftSize returns the width of the left border. If borders contain
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the left edge, 0 is returned.
-func (s Style) GetBorderLeftWidth() int {
+func (s Style) GetBorderLeftSize() int {
 	if !s.getAsBool(borderLeftKey, false) {
 		return 0
 	}
-	return s.getBorderStyle().GetLeftWidth()
+	return s.getBorderStyle().GetLeftSize()
 }
 
 // GetBorderLeftWidth returns the width of the bottom border. If borders
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the left edge, 0 is returned.
-func (s Style) GetBorderBottomWidth() int {
+func (s Style) GetBorderBottomSize() int {
 	if !s.getAsBool(borderBottomKey, false) {
 		return 0
 	}
-	return s.getBorderStyle().GetBottomWidth()
+	return s.getBorderStyle().GetBottomSize()
 }
 
-// GetBorderRightWidth returns the width of the right border. If borders
+// GetBorderRightSize returns the width of the right border. If borders
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the right edge, 0 is returned.
-func (s Style) GetBorderRightWidth() int {
+func (s Style) GetBorderRightSize() int {
 	if !s.getAsBool(borderRightKey, false) {
 		return 0
 	}
-	return s.getBorderStyle().GetBottomWidth()
+	return s.getBorderStyle().GetBottomSize()
 }
 
-// GetHorizontalBorderWidth returns the width of the horizontal borders. If
+// GetHorizontalBorderSize returns the width of the horizontal borders. If
 // borders contain runes of varying widths, the widest rune is returned. If no
 // border exists on the horizontal edges, 0 is returned.
-func (s Style) GetHorizontalBorderWidth() int {
+func (s Style) GetHorizontalBorderSize() int {
 	b := s.getBorderStyle()
-	return b.GetLeftWidth() + b.GetRightWidth()
+	return b.GetLeftSize() + b.GetRightSize()
 }
 
-// GetVerticalBorderWidth returns the width of the horizontal borders. If
+// GetVerticalBorderSize returns the width of the horizontal borders. If
 // borders contain runes of varying widths, the widest rune is returned. If no
 // border exists on the horizontal edges, 0 is returned.
-func (s Style) GetVerticalBorderWidth() int {
+func (s Style) GetVerticalBorderSize() int {
 	b := s.getBorderStyle()
-	return b.GetTopWidth() + b.GetBottomWidth()
+	return b.GetTopSize() + b.GetBottomSize()
 }
 
 // GetInline returns the style's inline setting. If no value is set false is
@@ -353,16 +353,26 @@ func (s Style) GetStrikethroughSpaces() bool {
 	return s.getAsBool(strikethroughSpacesKey, false)
 }
 
-// GetHorizontalGaps returns the sum of the style's horizontal margins, padding
+// GetHorizontalFrameSize returns the sum of the style's horizontal margins, padding
 // and border widths.
-func (s Style) GetHorizontalGaps() int {
-	return s.GetHorizontalMargins() + s.GetHorizontalPadding() + s.GetHorizontalBorderWidth()
+//
+// Provisional: this method may be renamed.
+func (s Style) GetHorizontalFrameSize() int {
+	return s.GetHorizontalMargins() + s.GetHorizontalPadding() + s.GetHorizontalBorderSize()
 }
 
-// GetVerticalGaps returns the sum of the style's horizontal margins, padding
+// GetVerticalFrameSize returns the sum of the style's horizontal margins, padding
 // and border widths.
-func (s Style) GetVerticalGaps() int {
-	return s.GetVerticalMargins() + s.GetVerticalPadding() + s.GetVerticalBorderWidth()
+//
+// Provisional: this method may be renamed.
+func (s Style) GetVerticalFrameSize() int {
+	return s.GetVerticalMargins() + s.GetVerticalPadding() + s.GetVerticalBorderSize()
+}
+
+// GetFrameSize returns the sum of the margins, padding and border width for
+// both the horizontal and vertical margins.
+func (s Style) GetFrameSize() (x, y int) {
+	return s.GetHorizontalFrameSize(), s.GetVerticalFrameSize()
 }
 
 // Returns whether or not the given property is set.

--- a/get.go
+++ b/get.go
@@ -182,7 +182,7 @@ func (s Style) GetVerticalMargins() int {
 // border style, Border{} is returned. For all other unset values false is
 // returend.
 func (s Style) GetBorder() (b Border, top, right, bottom, left bool) {
-	return s.getAsBorderStyle(borderStyleKey),
+	return s.getBorderStyle(),
 		s.getAsBool(borderTopKey, false),
 		s.getAsBool(borderRightKey, false),
 		s.getAsBool(borderBottomKey, false),
@@ -192,7 +192,7 @@ func (s Style) GetBorder() (b Border, top, right, bottom, left bool) {
 // GetBorderStyle returns the style's border style (type Border). If no value
 // is set Border{} is returned.
 func (s Style) GetBorderStyle() Border {
-	return s.getAsBorderStyle(borderStyleKey)
+	return s.getBorderStyle()
 }
 
 // GetBorderTop returns the style's top border setting. If no value is set
@@ -271,35 +271,35 @@ func (s Style) GetBorderLeftBackground() TerminalColor {
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the top edge, 0 is returned.
 func (s Style) GetBorderTopWidth() int {
-	return s.getAsBorderStyle(borderStyleKey).GetTopWidth()
+	return s.getBorderStyle().GetTopWidth()
 }
 
 // GetBorderLeftWidth returns the width of the left border. If borders contain
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the left edge, 0 is returned.
 func (s Style) GetBorderLeftWidth() int {
-	return s.getAsBorderStyle(borderStyleKey).GetLeftWidth()
+	return s.getBorderStyle().GetLeftWidth()
 }
 
 // GetBorderLeftWidth returns the width of the bottom border. If borders
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the left edge, 0 is returned.
 func (s Style) GetBorderBottomWidth() int {
-	return s.getAsBorderStyle(borderStyleKey).GetBottomWidth()
+	return s.getBorderStyle().GetBottomWidth()
 }
 
 // GetBorderRightWidth returns the width of the right border. If borders
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the right edge, 0 is returned.
 func (s Style) GetBorderRightWidth() int {
-	return s.getAsBorderStyle(borderStyleKey).GetBottomWidth()
+	return s.getBorderStyle().GetBottomWidth()
 }
 
 // GetHorizontalBorderWidth returns the width of the horizontal borders. If
 // borders contain runes of varying widths, the widest rune is returned. If no
 // border exists on the horizontal edges, 0 is returned.
 func (s Style) GetHorizontalBorderWidth() int {
-	b := s.getAsBorderStyle(borderStyleKey)
+	b := s.getBorderStyle()
 	return b.GetLeftWidth() + b.GetRightWidth()
 }
 
@@ -307,7 +307,7 @@ func (s Style) GetHorizontalBorderWidth() int {
 // borders contain runes of varying widths, the widest rune is returned. If no
 // border exists on the horizontal edges, 0 is returned.
 func (s Style) GetVerticalBorderWidth() int {
-	b := s.getAsBorderStyle(borderStyleKey)
+	b := s.getBorderStyle()
 	return b.GetTopWidth() + b.GetBottomWidth()
 }
 
@@ -403,8 +403,8 @@ func (s Style) getAsPosition(k propKey) Position {
 	return Position(0)
 }
 
-func (s Style) getAsBorderStyle(k propKey) Border {
-	v, ok := s.rules[k]
+func (s Style) getBorderStyle() Border {
+	v, ok := s.rules[borderStyleKey]
 	if !ok {
 		return noBorder
 	}

--- a/get.go
+++ b/get.go
@@ -243,6 +243,50 @@ func (s Style) GetBorderLeftBackground() TerminalColor {
 	return s.getAsColor(borderLeftBackgroundKey)
 }
 
+// GetBorderTopWidth returns the width of the top border. If borders contain
+// runes of varying widths, the widest rune is returned. If no border exists on
+// the top edge, 0 is returned.
+func (s Style) GetBorderTopWidth() int {
+	return s.getAsBorderStyle(borderStyleKey).GetTopWidth()
+}
+
+// GetBorderLeftWidth returns the width of the left border. If borders contain
+// runes of varying widths, the widest rune is returned. If no border exists on
+// the left edge, 0 is returned.
+func (s Style) GetBorderLeftWidth() int {
+	return s.getAsBorderStyle(borderStyleKey).GetLeftWidth()
+}
+
+// GetBorderLeftWidth returns the width of the bottom border. If borders
+// contain runes of varying widths, the widest rune is returned. If no border
+// exists on the left edge, 0 is returned.
+func (s Style) GetBorderBottomWidth() int {
+	return s.getAsBorderStyle(borderStyleKey).GetBottomWidth()
+}
+
+// GetBorderRightWidth returns the width of the right border. If borders
+// contain runes of varying widths, the widest rune is returned. If no border
+// exists on the right edge, 0 is returned.
+func (s Style) GetBorderRightWidth() int {
+	return s.getAsBorderStyle(borderStyleKey).GetBottomWidth()
+}
+
+// GetHorizontalBorderWidth returns the width of the horizontal borders. If
+// borders contain runes of varying widths, the widest rune is returned. If no
+// border exists on the horizontal edges, 0 is returned.
+func (s Style) GetHorizontalBorderWidth() int {
+	b := s.getAsBorderStyle(borderStyleKey)
+	return b.GetLeftWidth() + b.GetRightWidth()
+}
+
+// GetVerticalBorderWidth returns the width of the horizontal borders. If
+// borders contain runes of varying widths, the widest rune is returned. If no
+// border exists on the horizontal edges, 0 is returned.
+func (s Style) GetVerticalBorderWidth() int {
+	b := s.getAsBorderStyle(borderStyleKey)
+	return b.GetTopWidth() + b.GetBottomWidth()
+}
+
 // GetInline returns the style's inline setting. If no value is set false is
 // returned.
 func (s Style) GetInline() bool {

--- a/get.go
+++ b/get.go
@@ -114,6 +114,18 @@ func (s Style) GetPaddingLeft() int {
 	return s.getAsInt(paddingLeftKey)
 }
 
+// GetHorizontalPadding returns the style's left and right padding. Unset
+// values are measured as 0.
+func (s Style) GetHorizontalPadding() int {
+	return s.getAsInt(paddingLeftKey) + s.getAsInt(paddingRightKey)
+}
+
+// GetVerticalPadding returns the style's top and bottom padding. Unset values
+// are measured as 0.
+func (s Style) GetVerticalPadding() int {
+	return s.getAsInt(paddingLeftKey) + s.getAsInt(paddingRightKey)
+}
+
 // GetColorWhitespace returns the style's whitespace coloring setting. If no
 // value is set false is returned.
 func (s Style) GetColorWhitespace() bool {
@@ -151,6 +163,18 @@ func (s Style) GetMarginBottom() int {
 // returned.
 func (s Style) GetMarginLeft() int {
 	return s.getAsInt(marginLeftKey)
+}
+
+// GetHorizontalMargins returns the style's left and right margins. Unset
+// values are measured as 0.
+func (s Style) GetHorizontalMargins() int {
+	return s.getAsInt(marginLeftKey) + s.getAsInt(marginRightKey)
+}
+
+// GetVerticalMargins returns the style's top and bottom padding. Unset values
+// are measured as 0.
+func (s Style) GetVerticalMargins() int {
+	return s.getAsInt(marginTopKey) + s.getAsInt(marginBottomKey)
 }
 
 // GetBorder returns the style's border style (type Border) and value for the
@@ -315,6 +339,18 @@ func (s Style) GetUnderlineSpaces() bool {
 // spaces. If not value is set false is returned.
 func (s Style) GetStrikethroughSpaces() bool {
 	return s.getAsBool(strikethroughSpacesKey, false)
+}
+
+// GetHorizontalGaps returns the sum of the style's horizontal margins, padding
+// and border widths.
+func (s Style) GetHorizontalGaps() int {
+	return s.GetHorizontalMargins() + s.GetHorizontalPadding() + s.GetHorizontalBorderWidth()
+}
+
+// GetVerticalGaps returns the sum of the style's horizontal margins, padding
+// and border widths.
+func (s Style) GetVerticalGaps() int {
+	return s.GetVerticalMargins() + s.GetVerticalPadding() + s.GetVerticalBorderWidth()
 }
 
 // Returns whether or not the given property is set.


### PR DESCRIPTION
This PR adds convenience functions for querying styles’ horizontal and vertical gaps, as well as new methods for querying border sizing. The most useful of these are, perhaps, the methods for querying vertical and horizontal margins, padding and border widths all at once:

* `Style.GetFrameSize() (x, y int)`
* `Style.GetVerticalFrameSize() int`
* `Style.GetHorizontalFrameSize() int`

## New

* Border-level methods for returning the width of an edge. The width widest rune in an edge will be returned.
  * `Border.GetTopSize() int`
  * `Border.GetRightSize() int`
  * `Border.GetBottomSize() int`
  * `Border.GetLeftSize() int` 
* Style-level methods for returning the width of a border edge. The width widest rune in an edge will be returned.
  * `Style.GetBorderTopSize() int`
  * `Style.GetBorderRightSize() int`
  * `Style.GetBorderBottomSize() int`
  * `Style.GetBorderLeftSize() int`
* Meta-getters for returning vertical and horizontal margins:
  *  `Style.GetHorizontalMargins() int`
  *  `Style.GetVerticalMargins() int`
* Meta-getters for returning vertical and horizontal padding:
  *  `Style.GetHorizontalPadding() int`
  *  `Style.GetVerticalPadding() int`
* Meta-getters for returning vertical and horizontal border widths:
  *  `Style.GetHorizontalBorderSize() int`
  *  `Style.GetVerticalBorderSize() int`
* Meta-getters for returning vertical and horizontal border widths:
  *  `Style.GetHorizontalBorderSize() int`
  *  `Style.GetVerticalBorderSize() int`
* Meta-getters for querying horizontal margins, padding, and border widths all at once:
  * `Style.GetVerticalFrameSize() int`
  * `Style.GetHorizontalFrameSize() int`
  * `Style.GetFrameSize() (x, y int)`