### PR TITLE
Force-wrap long Strings

### DIFF
--- a/style.go
+++ b/style.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/muesli/reflow/truncate"
 	"github.com/muesli/reflow/wordwrap"
+	"github.com/muesli/reflow/wrap"
 	"github.com/muesli/termenv"
 )
 
@@ -263,7 +264,9 @@ func (s Style) Render(str string) string {
 
 	// Word wrap
 	if !inline && width > 0 {
-		str = wordwrap.String(str, width-leftPadding-rightPadding)
+		wrapAt := width - leftPadding - rightPadding
+		str = wordwrap.String(str, wrapAt)
+		str = wrap.String(str, wrapAt) // force-wrap long strings
 	}
 
 	// Render core text


### PR DESCRIPTION
This update forces strings that run wider than the given width to wrap as a sensible default.

So, given the following code:

```go
s := lipgloss.NewStyle().
    BorderStyle(lipgloss.RoundedBorder()).
    Width(5).
    Render("Schnurrbart")

fmt.Println(s)
```

Prior to this update it would render as such:

```
╭─────╮
│Schnurrbart│
╰─────╯
```

After this update is renders as follows:

```
╭─────╮
│Schnu│
│rrbar│
│t    │
╰─────╯
```

We could potentially introduce a setting to disallow this behavior, however we'll examine that use when the need arises. Special thanks to @erikgeiser for the [upstream PR](https://github.com/muesli/reflow/pull/30) that made this a cinch.

Closes #43.