### PR TITLE
Fix JoinVertical behavior for non-edge non-center alignments

### DIFF
--- a/join.go
+++ b/join.go
@@ -157,8 +157,8 @@ func JoinVertical(pos Position, strs ...string) string {
 				}
 
 				split := int(math.Round(float64(w) * pos.value()))
-				left := w - split
-				right := w - left
+				right := w - split
+				left := w - right
 
 				b.WriteString(strings.Repeat(" ", left))
 				b.WriteString(line)

--- a/join_test.go
+++ b/join_test.go
@@ -1,0 +1,21 @@
+package lipgloss
+
+import "testing"
+
+func TestJoinVertical(t *testing.T) {
+	type test struct {
+		result   string
+		expected string
+	}
+	tests := []test{
+		{JoinVertical(0, "A", "BBBB"), "A   \nBBBB"},
+		{JoinVertical(1, "A", "BBBB"), "   A\nBBBB"},
+		{JoinVertical(0.25, "A", "BBBB"), " A  \nBBBB"},
+	}
+
+	for _, test := range tests {
+		if test.result != test.expected {
+			t.Errorf("Got \n%s\n, expected \n%s\n", test.result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
Currently, JoinVertical displays like this:

```
JoinVertical(0.00, "A", "BBBB")
A   
BBBB


JoinVertical(0.25, "A", "BBBB")
  A 
BBBB


JoinVertical(0.75, "A", "BBBB")
 A  
BBBB


JoinVertical(1.00, "A", "BBBB")
   A
BBBB
```

It seems more natural that 0.25 would be 25% of the way from 0 to 1, and 0.75 would be 75% of the way from 0 to 1. This pull request switches to that behavior, and adds a regression test for the change.