### PR TITLE
Add separate sets of hard- and soft-enforced linters

### DIFF
--- a/.github/workflows/lint-soft.yml
+++ b/.github/workflows/lint-soft.yml
@@ -1,4 +1,4 @@
-name: lint
+name: lint-soft
 on:
   push:
   pull_request:
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   golangci:
-    name: lint
+    name: lint-soft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,6 +18,6 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: golangci-lint command line arguments.
-          #args:
+          args: --config .golangci-soft.yml --issues-exit-code=0
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.golangci-soft.yml
+++ b/.golangci-soft.yml
@@ -1,0 +1,47 @@
+run:
+  tests: false
+
+issues:
+  include:
+    - EXC0001
+    - EXC0005
+    - EXC0011
+    - EXC0012
+    - EXC0013
+
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  enable:
+    # - dupl
+    - exhaustive
+    # - exhaustivestruct
+    - goconst
+    - godot
+    - godox
+    - gomnd
+    - gomoddirectives
+    - goprintffuncname
+    - ifshort
+    # - lll
+    - misspell
+    - nakedret
+    - nestif
+    - noctx
+    - nolintlint
+    - prealloc
+    - wrapcheck
+
+  # disable default linters, they are already enabled in .golangci.yml
+  disable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,20 +15,15 @@ issues:
 linters:
   enable:
     - bodyclose
-    - dupl
     - exportloopref
-    - goconst
-    - godot
-    - godox
     - goimports
-    - goprintffuncname
     - gosec
-    - ifshort
-    - misspell
-    - prealloc
+    - nilerr
+    - predeclared
     - revive
     - rowserrcheck
     - sqlclosecheck
+    - tparallel
     - unconvert
     - unparam
     - whitespace

--- a/ansi_unix.go
+++ b/ansi_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package lipgloss


### PR DESCRIPTION
Soft-enforced linters will only annotate code changes, hard-enforced linters actually make the workflow fail if they encounter an issue.

You can run the soft linters manually on your machine:

```bash
golangci-lint run --config .golangci-soft.yml
```