### PR TITLE
Use termenv's EnvColorProfile, which respects NO_COLOR and CLICOLOR_FORCE env vars

### DIFF
--- a/color.go
+++ b/color.go
@@ -24,7 +24,7 @@ var (
 func ColorProfile() termenv.Profile {
 	if !explicitColorProfile {
 		getColorProfile.Do(func() {
-			colorProfile = termenv.ColorProfile()
+			colorProfile = termenv.EnvColorProfile()
 		})
 	}
 	return colorProfile


### PR DESCRIPTION
With `CLICOLOR_FORCE` set, this enables ANSI output even when writing to a non-terminal.