### PR TITLE
don't overwrite background when inheriting

### DIFF
--- a/example/vet/main.go
+++ b/example/vet/main.go
@@ -1,1 +1,0 @@
-package vet

--- a/example/vet/main.go
+++ b/example/vet/main.go
@@ -1,0 +1,1 @@
+package vet

--- a/style.go
+++ b/style.go
@@ -137,6 +137,9 @@ func (s Style) Inherit(i Style) Style {
 			// Padding is not inherited
 			continue
 		case backgroundKey:
+			if _, exists := s.rules[k]; exists {
+				continue
+			}
 			s.rules[k] = v
 
 			// The margins also inherit the background color

--- a/style.go
+++ b/style.go
@@ -137,11 +137,6 @@ func (s Style) Inherit(i Style) Style {
 			// Padding is not inherited
 			continue
 		case backgroundKey:
-			if _, exists := s.rules[k]; exists {
-				continue
-			}
-			s.rules[k] = v
-
 			// The margins also inherit the background color
 			if !s.isSet(marginBackgroundKey) && !i.isSet(marginBackgroundKey) {
 				s.rules[marginBackgroundKey] = v


### PR DESCRIPTION
It's contra intuitive that `backgroundKey` is the only key that is **always inherited**. 