### PR TITLE
Use ReplaceAll instead of Replace with n=-1

### DIFF
--- a/style.go
+++ b/style.go
@@ -262,7 +262,7 @@ func (s Style) Render(str string) string {
 
 	// Strip newlines in single line mode
 	if inline {
-		str = strings.Replace(str, "\n", "", -1)
+		str = strings.ReplaceAll(str, "\n", "")
 	}
 
 	// Word wrap


### PR DESCRIPTION
`strings.Replace(str, "\n", "", -1)` is not as explicit as `strings.ReplaceAll(str, "\n", "")` , and thus, the latter should be preferred.