### PR TITLE
feat: Non-Interpolated Colors

### DIFF
--- a/color.go
+++ b/color.go
@@ -103,8 +103,7 @@ type TerminalColor interface {
 //
 // Example usage:
 //
-//     var style = someStyle.Copy().Background(lipgloss.NoColor{})
-//
+//	var style = someStyle.Copy().Background(lipgloss.NoColor{})
 type NoColor struct{}
 
 func (n NoColor) value() string {
@@ -128,9 +127,8 @@ var noColor = NoColor{}
 
 // Color specifies a color by hex or ANSI value. For example:
 //
-//     ansiColor := lipgloss.Color("21")
-//     hexColor := lipgloss.Color("#0000ff")
-//
+//	ansiColor := lipgloss.Color("21")
+//	hexColor := lipgloss.Color("#0000ff")
 type Color string
 
 func (c Color) value() string {
@@ -155,8 +153,7 @@ func (c Color) RGBA() (r, g, b, a uint32) {
 //
 // Example usage:
 //
-//     color := lipgloss.AdaptiveColor{Light: "#0000ff", Dark: "#000099"}
-//
+//	color := lipgloss.AdaptiveColor{Light: "#0000ff", Dark: "#000099"}
 type AdaptiveColor struct {
 	Light string
 	Dark  string

--- a/color.go
+++ b/color.go
@@ -117,7 +117,7 @@ func (n NoColor) color() termenv.Color {
 
 // RGBA returns the RGBA value of this color. Because we have to return
 // something, despite this color being the absence of color, we're returning
-// the same value that go-colorful returns on error:
+// black with 100% opacity.
 //
 // Red: 0x0, Green: 0x0, Blue: 0x0, Alpha: 0xFFFF.
 func (n NoColor) RGBA() (r, g, b, a uint32) {
@@ -145,11 +145,8 @@ func (c Color) color() termenv.Color {
 // interface. Note that on error we return black with 100% opacity, or:
 //
 // Red: 0x0, Green: 0x0, Blue: 0x0, Alpha: 0xFF.
-//
-// This is inline with go-colorful's default behavior.
 func (c Color) RGBA() (r, g, b, a uint32) {
-	cf := hexToColor(c.value())
-	return cf.RGBA()
+	return hexToColor(c.value()).RGBA()
 }
 
 // AdaptiveColor provides color options for light and dark backgrounds. The
@@ -180,8 +177,6 @@ func (ac AdaptiveColor) color() termenv.Color {
 // interface. Note that on error we return black with 100% opacity, or:
 //
 // Red: 0x0, Green: 0x0, Blue: 0x0, Alpha: 0xFF.
-//
-// This is inline with go-colorful's default behavior.
 func (ac AdaptiveColor) RGBA() (r, g, b, a uint32) {
 	cf := hexToColor(ac.value())
 	return cf.RGBA()
@@ -216,8 +211,6 @@ func (c CompleteColor) color() termenv.Color {
 // interface. Note that on error we return black with 100% opacity, or:
 //
 // Red: 0x0, Green: 0x0, Blue: 0x0, Alpha: 0xFFFF
-//
-// This is inline with go-colorful's default behavior.
 func (c CompleteColor) RGBA() (r, g, b, a uint32) {
 	return hexToColor(c.value()).RGBA()
 }
@@ -245,8 +238,6 @@ func (cac CompleteAdaptiveColor) color() termenv.Color {
 // interface. Note that on error we return black with 100% opacity, or:
 //
 // Red: 0x0, Green: 0x0, Blue: 0x0, Alpha: 0xFFFF
-//
-// This is inline with go-colorful's default behavior.
 func (cac CompleteAdaptiveColor) RGBA() (r, g, b, a uint32) {
 	return hexToColor(cac.value()).RGBA()
 }

--- a/color.go
+++ b/color.go
@@ -187,6 +187,70 @@ func (ac AdaptiveColor) RGBA() (r, g, b, a uint32) {
 	return cf.RGBA()
 }
 
+// CompleteColor specifies exact values for truecolor, ANSI256, and ANSI color
+// profiles. Automatic color degredation will not be performed.
+type CompleteColor struct {
+	TrueColor string
+	ANSI256   string
+	ANSI      string
+}
+
+func (c CompleteColor) value() string {
+	switch ColorProfile() {
+	case termenv.TrueColor:
+		return c.TrueColor
+	case termenv.ANSI256:
+		return c.ANSI256
+	case termenv.ANSI:
+		return c.ANSI
+	default:
+		return ""
+	}
+}
+
+func (c CompleteColor) color() termenv.Color {
+	return colorProfile.Color(c.value())
+}
+
+// RGBA returns the RGBA value of this color. This satisfies the Go Color
+// interface. Note that on error we return black with 100% opacity, or:
+//
+// Red: 0x0, Green: 0x0, Blue: 0x0, Alpha: 0xFFFF
+//
+// This is inline with go-colorful's default behavior.
+func (c CompleteColor) RGBA() (r, g, b, a uint32) {
+	return hexToColor(c.value()).RGBA()
+}
+
+// CompleteColor specifies exact values for truecolor, ANSI256, and ANSI color
+// profiles, with separate options for light and dark backgrounds. Automatic
+// color degredation will not be performed.
+type CompleteAdaptiveColor struct {
+	Light CompleteColor
+	Dark  CompleteColor
+}
+
+func (cac CompleteAdaptiveColor) value() string {
+	if HasDarkBackground() {
+		return cac.Dark.value()
+	}
+	return cac.Light.value()
+}
+
+func (cac CompleteAdaptiveColor) color() termenv.Color {
+	return ColorProfile().Color(cac.value())
+}
+
+// RGBA returns the RGBA value of this color. This satisfies the Go Color
+// interface. Note that on error we return black with 100% opacity, or:
+//
+// Red: 0x0, Green: 0x0, Blue: 0x0, Alpha: 0xFFFF
+//
+// This is inline with go-colorful's default behavior.
+func (cac CompleteAdaptiveColor) RGBA() (r, g, b, a uint32) {
+	return hexToColor(cac.value()).RGBA()
+}
+
 // hexToColor translates a hex color string (#RRGGBB or #RGB) into a color.RGB,
 // which satisfies the color.Color interface. If an invalid string is passed
 // black with 100% opacity will be returned: or, in hex format, 0x000000FF.

--- a/join.go
+++ b/join.go
@@ -17,15 +17,14 @@ import (
 //
 // Example:
 //
-//     blockB := "...\n...\n..."
-//     blockA := "...\n...\n...\n...\n..."
+//	blockB := "...\n...\n..."
+//	blockA := "...\n...\n...\n...\n..."
 //
-//     // Join 20% from the top
-//     str := lipgloss.JoinHorizontal(0.2, blockA, blockB)
+//	// Join 20% from the top
+//	str := lipgloss.JoinHorizontal(0.2, blockA, blockB)
 //
-//     // Join on the top edge
-//     str := lipgloss.JoinHorizontal(lipgloss.Top, blockA, blockB)
-//
+//	// Join on the top edge
+//	str := lipgloss.JoinHorizontal(lipgloss.Top, blockA, blockB)
 func JoinHorizontal(pos Position, strs ...string) string {
 	if len(strs) == 0 {
 		return ""
@@ -106,15 +105,14 @@ func JoinHorizontal(pos Position, strs ...string) string {
 //
 // Example:
 //
-//     blockB := "...\n...\n..."
-//     blockA := "...\n...\n...\n...\n..."
+//	blockB := "...\n...\n..."
+//	blockA := "...\n...\n...\n...\n..."
 //
-//     // Join 20% from the top
-//     str := lipgloss.JoinVertical(0.2, blockA, blockB)
+//	// Join 20% from the top
+//	str := lipgloss.JoinVertical(0.2, blockA, blockB)
 //
-//     // Join on the right edge
-//     str := lipgloss.JoinVertical(lipgloss.Right, blockA, blockB)
-//
+//	// Join on the right edge
+//	str := lipgloss.JoinVertical(lipgloss.Right, blockA, blockB)
 func JoinVertical(pos Position, strs ...string) string {
 	if len(strs) == 0 {
 		return ""

--- a/set.go
+++ b/set.go
@@ -73,12 +73,11 @@ func (s Style) Faint(v bool) Style {
 
 // Foreground sets a foreground color.
 //
-//     // Sets the foreground to blue
-//     s := lipgloss.NewStyle().Foreground(lipgloss.Color("#0000ff"))
+//	// Sets the foreground to blue
+//	s := lipgloss.NewStyle().Foreground(lipgloss.Color("#0000ff"))
 //
-//     // Removes the foreground color
-//     s.Foreground(lipgloss.NoColor)
-//
+//	// Removes the foreground color
+//	s.Foreground(lipgloss.NoColor)
 func (s Style) Foreground(c TerminalColor) Style {
 	s.set(foregroundKey, c)
 	return s
@@ -248,12 +247,11 @@ func (s Style) MarginBackground(c TerminalColor) Style {
 //
 // Examples:
 //
-//     // Applies borders to the top and bottom only
-//     lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false)
+//	// Applies borders to the top and bottom only
+//	lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false)
 //
-//     // Applies rounded borders to the right and bottom only
-//     lipgloss.NewStyle().Border(lipgloss.RoundedBorder(), false, true, true, false)
-//
+//	// Applies rounded borders to the right and bottom only
+//	lipgloss.NewStyle().Border(lipgloss.RoundedBorder(), false, true, true, false)
 func (s Style) Border(b Border, sides ...bool) Style {
 	s.set(borderStyleKey, b)
 
@@ -285,8 +283,7 @@ func (s Style) Border(b Border, sides ...bool) Style {
 //
 // Example:
 //
-//     lipgloss.NewStyle().BorderStyle(lipgloss.ThickBorder())
-//
+//	lipgloss.NewStyle().BorderStyle(lipgloss.ThickBorder())
 func (s Style) BorderStyle(b Border) Style {
 	s.set(borderStyleKey, b)
 	return s
@@ -445,10 +442,9 @@ func (s Style) BorderLeftBackground(c TerminalColor) Style {
 //
 // Example:
 //
-//     var userInput string = "..."
-//     var userStyle = text.Style{ /* ... */ }
-//     fmt.Println(userStyle.Inline(true).Render(userInput))
-//
+//	var userInput string = "..."
+//	var userStyle = text.Style{ /* ... */ }
+//	fmt.Println(userStyle.Inline(true).Render(userInput))
 func (s Style) Inline(v bool) Style {
 	o := s.Copy()
 	o.set(inlineKey, v)
@@ -464,10 +460,9 @@ func (s Style) Inline(v bool) Style {
 //
 // Example:
 //
-//     var userInput string = "..."
-//     var userStyle = text.Style{ /* ... */ }
-//     fmt.Println(userStyle.MaxWidth(16).Render(userInput))
-//
+//	var userInput string = "..."
+//	var userStyle = text.Style{ /* ... */ }
+//	fmt.Println(userStyle.MaxWidth(16).Render(userInput))
 func (s Style) MaxWidth(n int) Style {
 	o := s.Copy()
 	o.set(maxWidthKey, n)


### PR DESCRIPTION
This revision introduces two new color types `CompleteColor` and `CompleteAdaptiveColor`. Not for the faint of heart, these types are for bypassing automatic color interpolation so you can specify exact colors for all color profiles:

```go
cc := CompleteColor{
	TrueColor: "#6B51FF",
	ANSI256: "63",
	ANSI: "5",
}

cac := CompleteAdaptiveColor{
	Light: CompleteColor{
		TrueColor: "#FF51CE",
		ANSI256: "213",
		ANSI: "5",
	},
	Dark: CompleteColor{
		TrueColor: "#6B51FF",
		ANSI256: "63",
		ANSI: "5",
	},
}
```

Keep in mind that profiles that do not receive definitions will not be interpolated and will render as black.