### PR TITLE
docs(lint): update example code in GoDocs per new style standard

### DIFF
--- a/color.go
+++ b/color.go
@@ -103,8 +103,7 @@ type TerminalColor interface {
 //
 // Example usage:
 //
-//     var style = someStyle.Copy().Background(lipgloss.NoColor{})
-//
+//	var style = someStyle.Copy().Background(lipgloss.NoColor{})
 type NoColor struct{}
 
 func (n NoColor) value() string {
@@ -128,9 +127,8 @@ var noColor = NoColor{}
 
 // Color specifies a color by hex or ANSI value. For example:
 //
-//     ansiColor := lipgloss.Color("21")
-//     hexColor := lipgloss.Color("#0000ff")
-//
+//	ansiColor := lipgloss.Color("21")
+//	hexColor := lipgloss.Color("#0000ff")
 type Color string
 
 func (c Color) value() string {
@@ -158,8 +156,7 @@ func (c Color) RGBA() (r, g, b, a uint32) {
 //
 // Example usage:
 //
-//     color := lipgloss.AdaptiveColor{Light: "#0000ff", Dark: "#000099"}
-//
+//	color := lipgloss.AdaptiveColor{Light: "#0000ff", Dark: "#000099"}
 type AdaptiveColor struct {
 	Light string
 	Dark  string

--- a/join.go
+++ b/join.go
@@ -17,15 +17,14 @@ import (
 //
 // Example:
 //
-//     blockB := "...\n...\n..."
-//     blockA := "...\n...\n...\n...\n..."
+//	blockB := "...\n...\n..."
+//	blockA := "...\n...\n...\n...\n..."
 //
-//     // Join 20% from the top
-//     str := lipgloss.JoinHorizontal(0.2, blockA, blockB)
+//	// Join 20% from the top
+//	str := lipgloss.JoinHorizontal(0.2, blockA, blockB)
 //
-//     // Join on the top edge
-//     str := lipgloss.JoinHorizontal(lipgloss.Top, blockA, blockB)
-//
+//	// Join on the top edge
+//	str := lipgloss.JoinHorizontal(lipgloss.Top, blockA, blockB)
 func JoinHorizontal(pos Position, strs ...string) string {
 	if len(strs) == 0 {
 		return ""
@@ -106,15 +105,14 @@ func JoinHorizontal(pos Position, strs ...string) string {
 //
 // Example:
 //
-//     blockB := "...\n...\n..."
-//     blockA := "...\n...\n...\n...\n..."
+//	blockB := "...\n...\n..."
+//	blockA := "...\n...\n...\n...\n..."
 //
-//     // Join 20% from the top
-//     str := lipgloss.JoinVertical(0.2, blockA, blockB)
+//	// Join 20% from the top
+//	str := lipgloss.JoinVertical(0.2, blockA, blockB)
 //
-//     // Join on the right edge
-//     str := lipgloss.JoinVertical(lipgloss.Right, blockA, blockB)
-//
+//	// Join on the right edge
+//	str := lipgloss.JoinVertical(lipgloss.Right, blockA, blockB)
 func JoinVertical(pos Position, strs ...string) string {
 	if len(strs) == 0 {
 		return ""

--- a/set.go
+++ b/set.go
@@ -73,12 +73,11 @@ func (s Style) Faint(v bool) Style {
 
 // Foreground sets a foreground color.
 //
-//     // Sets the foreground to blue
-//     s := lipgloss.NewStyle().Foreground(lipgloss.Color("#0000ff"))
+//	// Sets the foreground to blue
+//	s := lipgloss.NewStyle().Foreground(lipgloss.Color("#0000ff"))
 //
-//     // Removes the foreground color
-//     s.Foreground(lipgloss.NoColor)
-//
+//	// Removes the foreground color
+//	s.Foreground(lipgloss.NoColor)
 func (s Style) Foreground(c TerminalColor) Style {
 	s.set(foregroundKey, c)
 	return s
@@ -248,12 +247,11 @@ func (s Style) MarginBackground(c TerminalColor) Style {
 //
 // Examples:
 //
-//     // Applies borders to the top and bottom only
-//     lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false)
+//	// Applies borders to the top and bottom only
+//	lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false)
 //
-//     // Applies rounded borders to the right and bottom only
-//     lipgloss.NewStyle().Border(lipgloss.RoundedBorder(), false, true, true, false)
-//
+//	// Applies rounded borders to the right and bottom only
+//	lipgloss.NewStyle().Border(lipgloss.RoundedBorder(), false, true, true, false)
 func (s Style) Border(b Border, sides ...bool) Style {
 	s.set(borderStyleKey, b)
 
@@ -285,8 +283,7 @@ func (s Style) Border(b Border, sides ...bool) Style {
 //
 // Example:
 //
-//     lipgloss.NewStyle().BorderStyle(lipgloss.ThickBorder())
-//
+//	lipgloss.NewStyle().BorderStyle(lipgloss.ThickBorder())
 func (s Style) BorderStyle(b Border) Style {
 	s.set(borderStyleKey, b)
 	return s
@@ -445,10 +442,9 @@ func (s Style) BorderLeftBackground(c TerminalColor) Style {
 //
 // Example:
 //
-//     var userInput string = "..."
-//     var userStyle = text.Style{ /* ... */ }
-//     fmt.Println(userStyle.Inline(true).Render(userInput))
-//
+//	var userInput string = "..."
+//	var userStyle = text.Style{ /* ... */ }
+//	fmt.Println(userStyle.Inline(true).Render(userInput))
 func (s Style) Inline(v bool) Style {
 	o := s.Copy()
 	o.set(inlineKey, v)
@@ -464,10 +460,9 @@ func (s Style) Inline(v bool) Style {
 //
 // Example:
 //
-//     var userInput string = "..."
-//     var userStyle = text.Style{ /* ... */ }
-//     fmt.Println(userStyle.MaxWidth(16).Render(userInput))
-//
+//	var userInput string = "..."
+//	var userStyle = text.Style{ /* ... */ }
+//	fmt.Println(userStyle.MaxWidth(16).Render(userInput))
 func (s Style) MaxWidth(n int) Style {
 	o := s.Copy()
 	o.set(maxWidthKey, n)


### PR DESCRIPTION
Example code in GoDocs want to be intended with tabs these days. This revision was made automatically via `golangci-lint run --fix`.