### PR TITLE
Add BlockBorder, OuterHalfBlockBorder, and InnerHalfBlockBorder border styles

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -84,6 +84,17 @@ var (
 		BottomRight: "╯",
 	}
 
+	innerBorder = Border{
+		Top:         "▄",
+		Bottom:      "▀",
+		Left:        "▐",
+		Right:       "▌",
+		TopLeft:     "▗",
+		TopRight:    "▖",
+		BottomLeft:  "▝",
+		BottomRight: "▘",
+	}
+
 	thickBorder = Border{
 		Top:         "━",
 		Bottom:      "━",
@@ -127,6 +138,11 @@ func NormalBorder() Border {
 // RoundedBorder returns a border with rounded corners.
 func RoundedBorder() Border {
 	return roundedBorder
+}
+
+// InnerBorder returns a border that is inside the frame.
+func InnerBorder() Border {
+	return innerBorder
 }
 
 // ThickBorder returns a border that's thicker than the one returned by

--- a/borders.go
+++ b/borders.go
@@ -84,7 +84,29 @@ var (
 		BottomRight: "╯",
 	}
 
-	innerBorder = Border{
+	blockBorder = Border{
+		Top:         "█",
+		Bottom:      "█",
+		Left:        "█",
+		Right:       "█",
+		TopLeft:     "█",
+		TopRight:    "█",
+		BottomLeft:  "█",
+		BottomRight: "█",
+	}
+
+	outerHalfBlockBorder = Border{
+		Top:         "▀",
+		Bottom:      "▄",
+		Left:        "▌",
+		Right:       "▐",
+		TopLeft:     "▛",
+		TopRight:    "▜",
+		BottomLeft:  "▙",
+		BottomRight: "▟",
+	}
+
+	innerHalfBlockBorder = Border{
 		Top:         "▄",
 		Bottom:      "▀",
 		Left:        "▐",
@@ -140,9 +162,19 @@ func RoundedBorder() Border {
 	return roundedBorder
 }
 
-// InnerBorder returns a border that is inside the frame.
-func InnerBorder() Border {
-	return innerBorder
+// BlockBorder returns a border that takes the whole block.
+func BlockBorder() Border {
+	return blockBorder
+}
+
+// OuterHalfBlockBorder returns a half-block border that sits outside the frame.
+func OuterHalfBlockBorder() Border {
+	return outerHalfBlockBorder
+}
+
+// InnerHalfBlockBorder returns a half-block border that sits inside the frame.
+func InnerHalfBlockBorder() Border {
+	return innerHalfBlockBorder
 }
 
 // ThickBorder returns a border that's thicker than the one returned by

--- a/set.go
+++ b/set.go
@@ -278,8 +278,8 @@ func (s Style) Border(b Border, sides ...bool) Style {
 // the border style, the border will be enabled for all sides during rendering.
 //
 // You can define border characters as you'd like, though several default
-// styles are included: NormalBorder(), RoundedBorder(), ThickBorder(), and
-// DoubleBorder().
+// styles are included: NormalBorder(), RoundedBorder(), InnerBorder(),
+// ThickBorder(), and DoubleBorder().
 //
 // Example:
 //

--- a/set.go
+++ b/set.go
@@ -278,8 +278,9 @@ func (s Style) Border(b Border, sides ...bool) Style {
 // the border style, the border will be enabled for all sides during rendering.
 //
 // You can define border characters as you'd like, though several default
-// styles are included: NormalBorder(), RoundedBorder(), InnerBorder(),
-// ThickBorder(), and DoubleBorder().
+// styles are included: NormalBorder(), RoundedBorder(), BlockBorder(),
+// OuterHalfBlockBorder(), InnerHalfBlockBorder(), ThickBorder(),
+// and DoubleBorder().
 //
 // Example:
 //


### PR DESCRIPTION
By having the same color for the border and the background of the element, it gives some cool results:
<img width="165" alt="image" src="https://user-images.githubusercontent.com/2109178/188314857-e48ca604-5fc7-4fdc-a847-cb44a0226b9f.png">

For context, in a game where you can buy upgrades, you can show the user the ones that have been already bought, the ones they can buy, and the ones still locked:

<img width="739" alt="image" src="https://user-images.githubusercontent.com/2109178/188314548-9f9c254e-1efb-43b3-8ee1-c1e868f9ca1c.png">

I think it could be a useful addition, for example when you want to highlight something as if it was a button.

---

Quick testing:

```go
package main

import (
	"fmt"

	"github.com/charmbracelet/lipgloss"
)

var (
	innerBorder = lipgloss.Border{
		Top:         "▄",
		Bottom:      "▀",
		Left:        "▐",
		Right:       "▌",
		TopLeft:     "▗",
		TopRight:    "▖",
		BottomLeft:  "▝",
		BottomRight: "▘",
	}
)

func main() {
	fmt.Println()
	color := lipgloss.Color("#00f5d4)")
	testBorders := lipgloss.NewStyle().Foreground(lipgloss.Color("#333")).Background(color).BorderForeground(color)
	fmt.Println(testBorders.Copy().Border(lipgloss.NormalBorder()).Render("NormalBorder"))
	fmt.Println(testBorders.Copy().Border(lipgloss.RoundedBorder()).Render("RoundedBorder"))
	fmt.Println(testBorders.Copy().Border(innerBorder).Render("InnerBorder"))
	fmt.Println(testBorders.Copy().Border(lipgloss.ThickBorder()).Render("ThickBorder"))
	fmt.Println(testBorders.Copy().Border(lipgloss.DoubleBorder()).Render("DoubleBorder"))
	fmt.Println(testBorders.Copy().Border(lipgloss.HiddenBorder()).Render("HiddenBorder"))
}
```