### PR TITLE
fix: Replace  `\n` with a space in Inline style

### DIFF
--- a/style.go
+++ b/style.go
@@ -264,6 +264,7 @@ func (s Style) Render(str string) string {
 
 	// Strip newlines in single line mode
 	if inline {
+		str = strings.Trim(str, "\n")
 		str = strings.ReplaceAll(str, "\n", " ")
 	}
 

--- a/style.go
+++ b/style.go
@@ -264,7 +264,7 @@ func (s Style) Render(str string) string {
 
 	// Strip newlines in single line mode
 	if inline {
-		str = strings.ReplaceAll(str, "\n", "")
+		str = strings.ReplaceAll(str, "\n", " ")
 	}
 
 	// Word wrap


### PR DESCRIPTION
Fixes #116

This a straightforward modification but I want some clarification,
- Should we trim trailing `\n` as it would add a trailing space?


