### PR TITLE
chore: unify get border size function names

### DIFF
--- a/get.go
+++ b/get.go
@@ -290,7 +290,16 @@ func (s Style) GetBorderLeftBackground() TerminalColor {
 // GetBorderTopWidth returns the width of the top border. If borders contain
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the top edge, 0 is returned.
+//
+// Deprecated: This function simply calls Style.GetBorderTopSize.
 func (s Style) GetBorderTopWidth() int {
+	return s.GetBorderTopSize()
+}
+
+// GetBorderTopSize returns the width of the top border. If borders contain
+// runes of varying widths, the widest rune is returned. If no border exists on
+// the top edge, 0 is returned.
+func (s Style) GetBorderTopSize() int {
 	if !s.getAsBool(borderTopKey, false) {
 		return 0
 	}


### PR DESCRIPTION
Current functions to access the width of the borders directly on `lipgloss.Style`.

- `GetBorderTopWidth`
- `GetBorderLeftSize`
- `GetBorderBottomSize`
- `GetBorderRightSize`

From this list `GetBorderTopWidth` is a bit of an odd function name compared to the rest because it has different suffix. This PR adds `GetBorderTopSize` and deprecates `GetBorderTopWidth`.