### PR TITLE
Introduce style merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,23 @@ var styleB = lipgloss.NewStyle().
 ```
 
 
+## Merging
+
+Styles can merge rules from other styles. When merging, all rules
+on the receiver are merged.
+
+```go
+var styleA = lipgloss.NewStyle().
+    Foreground(lipgloss.Color("229")).
+    Background(lipgloss.Color("63"))
+
+// Both foreground and background colors will be merged:
+var styleB = lipgloss.NewStyle().
+    Foreground(lipgloss.Color("201")).
+    Merge(styleA)
+```
+
+
 ## Unsetting Rules
 
 All rules can be unset:

--- a/style.go
+++ b/style.go
@@ -152,6 +152,29 @@ func (s Style) Inherit(i Style) Style {
 	return s
 }
 
+// Merge overlays the style in the argument onto this style by copying each explicitly
+// set value from the argument style onto this style, even if it is already explicitly set.
+// Existing set values are overwritten.
+//
+// Margins, padding, and underlying string values are not merged.
+func (s Style) Merge(i Style) Style {
+	s.init()
+
+	for k, v := range i.rules {
+		switch k {
+		case marginTopKey, marginRightKey, marginBottomKey, marginLeftKey:
+			// Margins are not merged
+			continue
+		case paddingTopKey, paddingRightKey, paddingBottomKey, paddingLeftKey:
+			// Padding is not merged
+			continue
+		}
+
+		s.rules[k] = v
+	}
+	return s
+}
+
 // Render applies the defined style formatting to a given string.
 func (s Style) Render(str string) string {
 	var (

--- a/style_test.go
+++ b/style_test.go
@@ -78,25 +78,133 @@ func TestStyleInherit(t *testing.T) {
 		Margin(1, 1, 1, 1).
 		Padding(1, 1, 1, 1)
 
-	i := NewStyle().Inherit(s)
+	t.Run("empty", func(t *testing.T) {
+		i := NewStyle()
+		i = i.Inherit(s)
 
-	require.Equal(t, s.GetBold(), i.GetBold())
-	require.Equal(t, s.GetItalic(), i.GetItalic())
-	require.Equal(t, s.GetUnderline(), i.GetUnderline())
-	require.Equal(t, s.GetStrikethrough(), i.GetStrikethrough())
-	require.Equal(t, s.GetBlink(), i.GetBlink())
-	require.Equal(t, s.GetFaint(), i.GetFaint())
-	require.Equal(t, s.GetForeground(), i.GetForeground())
-	require.Equal(t, s.GetBackground(), i.GetBackground())
+		require.Equal(t, s.GetBold(), i.GetBold())
+		require.Equal(t, s.GetItalic(), i.GetItalic())
+		require.Equal(t, s.GetUnderline(), i.GetUnderline())
+		require.Equal(t, s.GetStrikethrough(), i.GetStrikethrough())
+		require.Equal(t, s.GetBlink(), i.GetBlink())
+		require.Equal(t, s.GetFaint(), i.GetFaint())
+		require.Equal(t, s.GetForeground(), i.GetForeground())
+		require.Equal(t, s.GetBackground(), i.GetBackground())
 
-	require.NotEqual(t, s.GetMarginLeft(), i.GetMarginLeft())
-	require.NotEqual(t, s.GetMarginRight(), i.GetMarginRight())
-	require.NotEqual(t, s.GetMarginTop(), i.GetMarginTop())
-	require.NotEqual(t, s.GetMarginBottom(), i.GetMarginBottom())
-	require.NotEqual(t, s.GetPaddingLeft(), i.GetPaddingLeft())
-	require.NotEqual(t, s.GetPaddingRight(), i.GetPaddingRight())
-	require.NotEqual(t, s.GetPaddingTop(), i.GetPaddingTop())
-	require.NotEqual(t, s.GetPaddingBottom(), i.GetPaddingBottom())
+		require.NotEqual(t, s.GetMarginLeft(), i.GetMarginLeft())
+		require.NotEqual(t, s.GetMarginRight(), i.GetMarginRight())
+		require.NotEqual(t, s.GetMarginTop(), i.GetMarginTop())
+		require.NotEqual(t, s.GetMarginBottom(), i.GetMarginBottom())
+		require.NotEqual(t, s.GetPaddingLeft(), i.GetPaddingLeft())
+		require.NotEqual(t, s.GetPaddingRight(), i.GetPaddingRight())
+		require.NotEqual(t, s.GetPaddingTop(), i.GetPaddingTop())
+		require.NotEqual(t, s.GetPaddingBottom(), i.GetPaddingBottom())
+	})
+
+	t.Run("set", func(t *testing.T) {
+		i := NewStyle().
+			Bold(false).
+			Italic(false).
+			Underline(false).
+			Strikethrough(false).
+			Blink(false).
+			Faint(false).
+			Foreground(Color("#00000000")).
+			Background(Color("#22222222")).
+			Margin(2, 2, 2, 2).
+			Padding(2, 2, 2, 2)
+		i = i.Inherit(s)
+
+		require.NotEqual(t, s.GetBold(), i.GetBold())
+		require.NotEqual(t, s.GetItalic(), i.GetItalic())
+		require.NotEqual(t, s.GetUnderline(), i.GetUnderline())
+		require.NotEqual(t, s.GetStrikethrough(), i.GetStrikethrough())
+		require.NotEqual(t, s.GetBlink(), i.GetBlink())
+		require.NotEqual(t, s.GetFaint(), i.GetFaint())
+		require.NotEqual(t, s.GetForeground(), i.GetForeground())
+		require.NotEqual(t, s.GetBackground(), i.GetBackground())
+
+		require.NotEqual(t, s.GetMarginLeft(), i.GetMarginLeft())
+		require.NotEqual(t, s.GetMarginRight(), i.GetMarginRight())
+		require.NotEqual(t, s.GetMarginTop(), i.GetMarginTop())
+		require.NotEqual(t, s.GetMarginBottom(), i.GetMarginBottom())
+		require.NotEqual(t, s.GetPaddingLeft(), i.GetPaddingLeft())
+		require.NotEqual(t, s.GetPaddingRight(), i.GetPaddingRight())
+		require.NotEqual(t, s.GetPaddingTop(), i.GetPaddingTop())
+		require.NotEqual(t, s.GetPaddingBottom(), i.GetPaddingBottom())
+	})
+}
+
+func TestStyleMerge(t *testing.T) {
+	t.Parallel()
+
+	s := NewStyle().
+		Bold(true).
+		Italic(true).
+		Underline(true).
+		Strikethrough(true).
+		Blink(true).
+		Faint(true).
+		Foreground(Color("#ffffff")).
+		Background(Color("#111111")).
+		Margin(1, 1, 1, 1).
+		Padding(1, 1, 1, 1)
+
+	t.Run("empty", func(t *testing.T) {
+		m := NewStyle()
+		m = m.Merge(s)
+
+		require.Equal(t, s.GetBold(), m.GetBold())
+		require.Equal(t, s.GetItalic(), m.GetItalic())
+		require.Equal(t, s.GetUnderline(), m.GetUnderline())
+		require.Equal(t, s.GetStrikethrough(), m.GetStrikethrough())
+		require.Equal(t, s.GetBlink(), m.GetBlink())
+		require.Equal(t, s.GetFaint(), m.GetFaint())
+		require.Equal(t, s.GetForeground(), m.GetForeground())
+		require.Equal(t, s.GetBackground(), m.GetBackground())
+
+		require.NotEqual(t, s.GetMarginLeft(), m.GetMarginLeft())
+		require.NotEqual(t, s.GetMarginRight(), m.GetMarginRight())
+		require.NotEqual(t, s.GetMarginTop(), m.GetMarginTop())
+		require.NotEqual(t, s.GetMarginBottom(), m.GetMarginBottom())
+		require.NotEqual(t, s.GetPaddingLeft(), m.GetPaddingLeft())
+		require.NotEqual(t, s.GetPaddingRight(), m.GetPaddingRight())
+		require.NotEqual(t, s.GetPaddingTop(), m.GetPaddingTop())
+		require.NotEqual(t, s.GetPaddingBottom(), m.GetPaddingBottom())
+	})
+
+	t.Run("set", func(t *testing.T) {
+		m := NewStyle().
+			Bold(false).
+			Italic(false).
+			Underline(false).
+			Strikethrough(false).
+			Blink(false).
+			Faint(false).
+			Foreground(Color("#00000000")).
+			Background(Color("#22222222")).
+			Margin(2, 2, 2, 2).
+			Padding(2, 2, 2, 2)
+		m = m.Merge(s)
+
+		require.Equal(t, s.GetBold(), m.GetBold())
+		require.Equal(t, s.GetItalic(), m.GetItalic())
+		require.Equal(t, s.GetUnderline(), m.GetUnderline())
+		require.Equal(t, s.GetStrikethrough(), m.GetStrikethrough())
+		require.Equal(t, s.GetBlink(), m.GetBlink())
+		require.Equal(t, s.GetFaint(), m.GetFaint())
+		require.Equal(t, s.GetForeground(), m.GetForeground())
+		require.Equal(t, s.GetBackground(), m.GetBackground())
+
+		require.NotEqual(t, s.GetMarginLeft(), m.GetMarginLeft())
+		require.NotEqual(t, s.GetMarginRight(), m.GetMarginRight())
+		require.NotEqual(t, s.GetMarginTop(), m.GetMarginTop())
+		require.NotEqual(t, s.GetMarginBottom(), m.GetMarginBottom())
+		require.NotEqual(t, s.GetPaddingLeft(), m.GetPaddingLeft())
+		require.NotEqual(t, s.GetPaddingRight(), m.GetPaddingRight())
+		require.NotEqual(t, s.GetPaddingTop(), m.GetPaddingTop())
+		require.NotEqual(t, s.GetPaddingBottom(), m.GetPaddingBottom())
+	})
 }
 
 func TestStyleCopy(t *testing.T) {


### PR DESCRIPTION
This is the opposite of inheritance, where all values are overwritten, even if already set.

Especially useful when you want to overwrite third parties styles (like bubbles list https://github.com/charmbracelet/bubbles/blob/master/list/style.go#L44) with your own styles :)

Note: i've enhanced the inherit tests a bit to better point the differences between the two methods.