### PR TITLE
fix: Align lines with emojis correctly

### DIFF
--- a/align.go
+++ b/align.go
@@ -3,7 +3,6 @@ package lipgloss
 import (
 	"strings"
 
-	"github.com/muesli/reflow/ansi"
 	"github.com/muesli/termenv"
 )
 
@@ -15,7 +14,7 @@ func alignTextHorizontal(str string, pos Position, width int, style *termenv.Sty
 	var b strings.Builder
 
 	for i, l := range lines {
-		lineWidth := ansi.PrintableRuneWidth(l)
+		lineWidth := PrintableStringWidth(l)
 
 		shortAmount := widestLine - lineWidth                // difference from the widest line
 		shortAmount += max(0, width-(shortAmount+lineWidth)) // difference from the total width, if set

--- a/borders.go
+++ b/borders.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/mattn/go-runewidth"
-	"github.com/muesli/reflow/ansi"
 	"github.com/muesli/termenv"
 )
 
@@ -384,8 +383,8 @@ func renderHorizontalEdge(left, middle, right string, width int) string {
 		middle = " "
 	}
 
-	leftWidth := ansi.PrintableRuneWidth(left)
-	rightWidth := ansi.PrintableRuneWidth(right)
+	leftWidth := PrintableStringWidth(left)
+	rightWidth := PrintableStringWidth(right)
 
 	runes := []rune(middle)
 	j := 0
@@ -398,7 +397,7 @@ func renderHorizontalEdge(left, middle, right string, width int) string {
 		if j >= len(runes) {
 			j = 0
 		}
-		i += ansi.PrintableRuneWidth(string(runes[j]))
+		i += PrintableStringWidth(string(runes[j]))
 	}
 	out.WriteString(right)
 

--- a/join.go
+++ b/join.go
@@ -3,8 +3,6 @@ package lipgloss
 import (
 	"math"
 	"strings"
-
-	"github.com/muesli/reflow/ansi"
 )
 
 // JoinHorizontal is a utility function for horizontally joining two
@@ -85,7 +83,7 @@ func JoinHorizontal(pos Position, strs ...string) string {
 			b.WriteString(block[i])
 
 			// Also make lines the same length
-			b.WriteString(strings.Repeat(" ", maxWidths[j]-ansi.PrintableRuneWidth(block[i])))
+			b.WriteString(strings.Repeat(" ", maxWidths[j]-PrintableStringWidth(block[i])))
 		}
 		if i < len(blocks[0])-1 {
 			b.WriteRune('\n')
@@ -137,7 +135,7 @@ func JoinVertical(pos Position, strs ...string) string {
 	var b strings.Builder
 	for i, block := range blocks {
 		for j, line := range block {
-			w := maxWidth - ansi.PrintableRuneWidth(line)
+			w := maxWidth - PrintableStringWidth(line)
 
 			switch pos { //nolint:exhaustive
 			case Left:

--- a/position.go
+++ b/position.go
@@ -3,8 +3,6 @@ package lipgloss
 import (
 	"math"
 	"strings"
-
-	"github.com/muesli/reflow/ansi"
 )
 
 // Position represents a position along a horizontal or vertical axis. It's in
@@ -66,7 +64,7 @@ func (r *Renderer) PlaceHorizontal(width int, pos Position, str string, opts ...
 	var b strings.Builder
 	for i, l := range lines {
 		// Is this line shorter than the longest line?
-		short := max(0, contentWidth-ansi.PrintableRuneWidth(l))
+		short := max(0, contentWidth-PrintableStringWidth(l))
 
 		switch pos { //nolint:exhaustive
 		case Left:

--- a/size.go
+++ b/size.go
@@ -2,8 +2,6 @@ package lipgloss
 
 import (
 	"strings"
-
-	"github.com/muesli/reflow/ansi"
 )
 
 // Width returns the cell width of characters in the string. ANSI sequences are
@@ -14,7 +12,7 @@ import (
 // will give you accurate results.
 func Width(str string) (width int) {
 	for _, l := range strings.Split(str, "\n") {
-		w := ansi.PrintableRuneWidth(l)
+		w := PrintableStringWidth(l)
 		if w > width {
 			width = w
 		}

--- a/whitespace.go
+++ b/whitespace.go
@@ -3,7 +3,6 @@ package lipgloss
 import (
 	"strings"
 
-	"github.com/muesli/reflow/ansi"
 	"github.com/muesli/termenv"
 )
 
@@ -45,12 +44,12 @@ func (w whitespace) render(width int) string {
 		if j >= len(r) {
 			j = 0
 		}
-		i += ansi.PrintableRuneWidth(string(r[j]))
+		i += PrintableStringWidth(string(r[j]))
 	}
 
 	// Fill any extra gaps white spaces. This might be necessary if any runes
 	// are more than one cell wide, which could leave a one-rune gap.
-	short := width - ansi.PrintableRuneWidth(b.String())
+	short := width - PrintableStringWidth(b.String())
 	if short > 0 {
 		b.WriteString(strings.Repeat(" ", short))
 	}


### PR DESCRIPTION
Alignment issues occur when some lines have certain emojis in them. This is caused by incorrectly calculating the width of a string.

For a string with emojis in them, it is important to understand that the string width is different to the rune width. Many functions within Lipgloss base the string length on the printable rune width which is incorrect. The correct method requires finding the string width.

The reflow package has a printable rune width function. While the ANSI sequences need to be removed, we do not want the rune width as this function returns.

This change adds a new function to get the printable string width. The code was taken from reflow and modified for use in Lipgloss. Since the printable rune width function in reflow works correctly, it was more reasonable to add the function to Lipgloss.