### PR TITLE
fix: don't concurrently change output profiles

### DIFF
--- a/style_test.go
+++ b/style_test.go
@@ -58,8 +58,6 @@ func TestStyleRender(t *testing.T) {
 }
 
 func TestStyleCustomRender(t *testing.T) {
-	t.Parallel()
-
 	r := NewRenderer(WithColorProfile(termenv.TrueColor), WithDarkBackground(false))
 	tt := []struct {
 		style    Style


### PR DESCRIPTION
Multiple lipgloss renderer instances can end up using the same default termenv.Output. This leads to a race condition when manipulating the ColorProfile concurrently.

We could mutex protect the standard output in termenv, but it feels like a weak promise, as the rest of the Output wouldn't (and probably shouldn't) get protected. Protecting it in lipgloss itself would require a global lock however.

I can't come up with a proper use-case for this scenario, and therefore we shift this responsibility to the user.