### PR TITLE
fix(renderer): use termenv default renderer

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -2,12 +2,15 @@ package lipgloss
 
 import (
 	"io"
-	"os"
 
 	"github.com/muesli/termenv"
 )
 
-var renderer = NewRenderer(os.Stdout)
+// We're manually creating the struct here to avoid initializing the output and
+// query the terminal multiple times.
+var renderer = &Renderer{
+	output: termenv.DefaultOutput(),
+}
 
 // Renderer is a lipgloss terminal renderer.
 type Renderer struct {

--- a/style.go
+++ b/style.go
@@ -173,7 +173,7 @@ func (s Style) Inherit(i Style) Style {
 // Render applies the defined style formatting to a given string.
 func (s Style) Render(strs ...string) string {
 	if s.r == nil {
-		s.r = DefaultRenderer()
+		s.r = renderer
 	}
 	if s.value != "" {
 		strs = append([]string{s.value}, strs...)


### PR DESCRIPTION
Creating a _new_ global termenv output clashes with the default global termenv output leading the terminal to block and freeze. Share the default termenv output with the global default lipgloss renderer.

Needs: https://github.com/muesli/termenv/pull/121