### PR TITLE
feat: convert tabs to spaces with `Style.TabWidth(int)`

### DIFF
--- a/get.go
+++ b/get.go
@@ -370,6 +370,12 @@ func (s Style) GetMaxHeight() int {
 	return s.getAsInt(maxHeightKey)
 }
 
+// GetTabWidth returns the style's tab width setting. If no value is set 4 is
+// returned which is the implicit default.
+func (s Style) GetTabWidth() int {
+	return s.getAsInt(tabWidthKey)
+}
+
 // GetUnderlineSpaces returns whether or not the style is set to underline
 // spaces. If not value is set false is returned.
 func (s Style) GetUnderlineSpaces() bool {

--- a/set.go
+++ b/set.go
@@ -14,7 +14,14 @@ func (s *Style) set(key propKey, value interface{}) {
 
 	switch v := value.(type) {
 	case int:
-		// We don't allow negative integers on any of our values, so just keep
+		// TabWidth is the only property that may have a negative value (and
+		// that negative value can be no less than -1).
+		if key == tabWidthKey {
+			s.rules[key] = v
+			break
+		}
+
+		// We don't allow negative integers on any of our other values, so just keep
 		// them at zero or above. We could use uints instead, but the
 		// conversions are a little tedious, so we're sticking with ints for
 		// sake of usability.
@@ -497,11 +504,24 @@ func (s Style) MaxWidth(n int) Style {
 // styles.
 //
 // Because this in intended to be used at the time of render, this method will
-// not mutate the style and instead return a copy.
+// not mutate the style and instead returns a copy.
 func (s Style) MaxHeight(n int) Style {
 	o := s.Copy()
 	o.set(maxHeightKey, n)
 	return o
+}
+
+// TabWidth sets the number of spaces that a tab (/t) should be rendered as.
+// When set to 0, tabs will be removed. To disable the replacement of tabs with
+// spaces entirely, set this to -1.
+//
+// By default, tabs will be removed and replaced with 4 spaces.
+func (s Style) TabWidth(n int) Style {
+	if n <= -1 {
+		n = -1
+	}
+	s.set(tabWidthKey, n)
+	return s
 }
 
 // UnderlineSpaces determines whether to underline spaces between words. By

--- a/set.go
+++ b/set.go
@@ -511,11 +511,15 @@ func (s Style) MaxHeight(n int) Style {
 	return o
 }
 
+// NoTabConversion can be passed to [Style.TabWidth] to disable the replacement
+// of tabs with spaces at render time.
+const NoTabConversion = -1
+
 // TabWidth sets the number of spaces that a tab (/t) should be rendered as.
 // When set to 0, tabs will be removed. To disable the replacement of tabs with
-// spaces entirely, set this to -1.
+// spaces entirely, set this to [NoTabConversion].
 //
-// By default, tabs will be removed and replaced with 4 spaces.
+// By default, tabs will be replaced with 4 spaces.
 func (s Style) TabWidth(n int) Style {
 	if n <= -1 {
 		n = -1

--- a/style_test.go
+++ b/style_test.go
@@ -181,7 +181,8 @@ func TestStyleCopy(t *testing.T) {
 		Foreground(Color("#ffffff")).
 		Background(Color("#111111")).
 		Margin(1, 1, 1, 1).
-		Padding(1, 1, 1, 1)
+		Padding(1, 1, 1, 1).
+		TabWidth(2)
 
 	i := s.Copy()
 
@@ -202,6 +203,7 @@ func TestStyleCopy(t *testing.T) {
 	requireEqual(t, s.GetPaddingRight(), i.GetPaddingRight())
 	requireEqual(t, s.GetPaddingTop(), i.GetPaddingTop())
 	requireEqual(t, s.GetPaddingBottom(), i.GetPaddingBottom())
+	requireEqual(t, s.GetTabWidth(), i.GetTabWidth())
 }
 
 func TestStyleUnset(t *testing.T) {
@@ -312,6 +314,12 @@ func TestStyleUnset(t *testing.T) {
 	requireTrue(t, s.GetBorderLeft())
 	s.UnsetBorderLeft()
 	requireFalse(t, s.GetBorderLeft())
+
+	// tab width
+	s = NewStyle().TabWidth(2)
+	requireEqual(t, s.GetTabWidth(), 2)
+	s.UnsetTabWidth()
+	requireNotEqual(t, s.GetTabWidth(), 4)
 }
 
 func TestStyleValue(t *testing.T) {
@@ -352,7 +360,17 @@ func TestStyleValue(t *testing.T) {
 				res, formatEscapes(res))
 		}
 	}
+}
 
+func TestTabConversion(t *testing.T) {
+	s := NewStyle()
+	requireEqual(t, "[    ]", s.Render("[\t]"))
+	s = NewStyle().TabWidth(2)
+	requireEqual(t, "[  ]", s.Render("[\t]"))
+	s = NewStyle().TabWidth(0)
+	requireEqual(t, "[]", s.Render("[\t]"))
+	s = NewStyle().TabWidth(-1)
+	requireEqual(t, "[\t]", s.Render("[\t]"))
 }
 
 func BenchmarkStyleRender(b *testing.B) {

--- a/unset.go
+++ b/unset.go
@@ -287,6 +287,12 @@ func (s Style) UnsetMaxHeight() Style {
 	return s
 }
 
+// UnsetMaxHeight removes the max height style rule, if set.
+func (s Style) UnsetTabWidth() Style {
+	delete(s.rules, tabWidthKey)
+	return s
+}
+
 // UnsetUnderlineSpaces removes the value set by UnderlineSpaces.
 func (s Style) UnsetUnderlineSpaces() Style {
 	delete(s.rules, underlineSpacesKey)


### PR DESCRIPTION
Lip Gloss currently mis-measures a tab (i.e. a `\t`) at 0 cells wide when they actually render at different widths in different terminals (usually 8 cells, sometimes 4 cells). For theses reasons tabs are almost never what you want when designing layouts for TUIs.

With this revision, a tab will get converted to 4 spaces by default—so this is a behavioral change—but you can customize the behavior and disable it entirely with the new `TabWidth(int)` method.

```go
s := lipgloss.NewStyle()        // 4 spaces per tab, the default
s = s.TabWidth(2)               // 2 spaces per tab
s = s.TabWidth(0)               // remove tabs
s = s.TabWidth(-1)              // don't convert tabs to spaces
s = s.TabWidth(NoTabConversion) // alias of the above
```

Disable the feature with `Style.TabWidth(-1)` feels a little kludgy but is perhaps okay with the addition of the `NoTabConversion` const. The alternative would be to have a separate method for disabling the behavior (`Style.DisableTabConversion(true)` or something) but what I don't love about that is that the two settings would then compete with each other.