### PR TITLE
chore(lint): add various nolint directives

### DIFF
--- a/align.go
+++ b/align.go
@@ -21,7 +21,7 @@ func alignTextHorizontal(str string, pos Position, width int, style *termenv.Sty
 		shortAmount += max(0, width-(shortAmount+lineWidth)) // difference from the total width, if set
 
 		if shortAmount > 0 {
-			switch pos {
+			switch pos { //nolint:exhaustive
 			case Right:
 				s := strings.Repeat(" ", shortAmount)
 				if style != nil {
@@ -29,8 +29,9 @@ func alignTextHorizontal(str string, pos Position, width int, style *termenv.Sty
 				}
 				l = s + l
 			case Center:
-				left := shortAmount / 2
-				right := left + shortAmount%2 // note that we put the remainder on the right
+				// Note: remainder goes on the right.
+				left := shortAmount / 2       //nolint:gomnd
+				right := left + shortAmount%2 //nolint:gomnd
 
 				leftSpaces := strings.Repeat(" ", left)
 				rightSpaces := strings.Repeat(" ", right)

--- a/color.go
+++ b/color.go
@@ -35,7 +35,7 @@ func (NoColor) color(*Renderer) termenv.Color {
 //
 // Deprecated.
 func (n NoColor) RGBA() (r, g, b, a uint32) {
-	return 0x0, 0x0, 0x0, 0xFFFF
+	return 0x0, 0x0, 0x0, 0xFFFF //nolint:gomnd
 }
 
 // Color specifies a color by hex or ANSI value. For example:
@@ -123,7 +123,7 @@ type CompleteColor struct {
 
 func (c CompleteColor) color(r *Renderer) termenv.Color {
 	p := r.ColorProfile()
-	switch p {
+	switch p { //nolint:exhaustive
 	case termenv.TrueColor:
 		return p.Color(c.TrueColor)
 	case termenv.ANSI256:

--- a/join.go
+++ b/join.go
@@ -60,7 +60,7 @@ func JoinHorizontal(pos Position, strs ...string) string {
 
 		extraLines := make([]string, maxHeight-len(blocks[i]))
 
-		switch pos {
+		switch pos { //nolint:exhaustive
 		case Top:
 			blocks[i] = append(blocks[i], extraLines...)
 
@@ -139,7 +139,7 @@ func JoinVertical(pos Position, strs ...string) string {
 		for j, line := range block {
 			w := maxWidth - ansi.PrintableRuneWidth(line)
 
-			switch pos {
+			switch pos { //nolint:exhaustive
 			case Left:
 				b.WriteString(line)
 				b.WriteString(strings.Repeat(" ", w))

--- a/position.go
+++ b/position.go
@@ -68,7 +68,7 @@ func (r *Renderer) PlaceHorizontal(width int, pos Position, str string, opts ...
 		// Is this line shorter than the longest line?
 		short := max(0, contentWidth-ansi.PrintableRuneWidth(l))
 
-		switch pos {
+		switch pos { //nolint:exhaustive
 		case Left:
 			b.WriteString(l)
 			b.WriteString(ws.render(gap + short))
@@ -121,7 +121,7 @@ func (r *Renderer) PlaceVertical(height int, pos Position, str string, opts ...W
 	emptyLine := ws.render(width)
 	b := strings.Builder{}
 
-	switch pos {
+	switch pos { //nolint:exhaustive
 	case Top:
 		b.WriteString(str)
 		b.WriteRune('\n')

--- a/set.go
+++ b/set.go
@@ -569,19 +569,19 @@ func whichSidesInt(i ...int) (top, right, bottom, left int, ok bool) {
 		left = i[0]
 		right = i[0]
 		ok = true
-	case 2:
+	case 2: //nolint:gomnd
 		top = i[0]
 		bottom = i[0]
 		left = i[1]
 		right = i[1]
 		ok = true
-	case 3:
+	case 3: //nolint:gomnd
 		top = i[0]
 		left = i[1]
 		right = i[1]
 		bottom = i[2]
 		ok = true
-	case 4:
+	case 4: //nolint:gomnd
 		top = i[0]
 		right = i[1]
 		bottom = i[2]
@@ -602,19 +602,19 @@ func whichSidesBool(i ...bool) (top, right, bottom, left bool, ok bool) {
 		left = i[0]
 		right = i[0]
 		ok = true
-	case 2:
+	case 2: //nolint:gomnd
 		top = i[0]
 		bottom = i[0]
 		left = i[1]
 		right = i[1]
 		ok = true
-	case 3:
+	case 3: //nolint:gomnd
 		top = i[0]
 		left = i[1]
 		right = i[1]
 		bottom = i[2]
 		ok = true
-	case 4:
+	case 4: //nolint:gomnd
 		top = i[0]
 		right = i[1]
 		bottom = i[2]
@@ -635,19 +635,19 @@ func whichSidesColor(i ...TerminalColor) (top, right, bottom, left TerminalColor
 		left = i[0]
 		right = i[0]
 		ok = true
-	case 2:
+	case 2: //nolint:gomnd
 		top = i[0]
 		bottom = i[0]
 		left = i[1]
 		right = i[1]
 		ok = true
-	case 3:
+	case 3: //nolint:gomnd
 		top = i[0]
 		left = i[1]
 		right = i[1]
 		bottom = i[2]
 		ok = true
-	case 4:
+	case 4: //nolint:gomnd
 		top = i[0]
 		right = i[1]
 		bottom = i[2]

--- a/style.go
+++ b/style.go
@@ -151,7 +151,7 @@ func (s Style) Inherit(i Style) Style {
 	s.init()
 
 	for k, v := range i.rules {
-		switch k {
+		switch k { //nolint:exhaustive
 		case marginTopKey, marginRightKey, marginBottomKey, marginLeftKey:
 			// Margins are not inherited
 			continue


### PR DESCRIPTION
Generally run-of-the-mill directives to disable magic number and exhaustive switches. Reasonings should be self explanatory while reading the code and comments, where applicable.