### PR TITLE
fix: always render horizontal border edge when enabled

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -376,10 +376,6 @@ func (s Style) applyBorder(str string) string {
 
 // Render the horizontal (top or bottom) portion of a border.
 func renderHorizontalEdge(left, middle, right string, width int) string {
-	if width < 1 {
-		return ""
-	}
-
 	if middle == "" {
 		middle = " "
 	}


### PR DESCRIPTION
When a style has a border set and an empty string is rendered, it should still render the border. When the left border is set, width is incremented by 1, so in most cases the width will not be 0.

When we render an empty string, with a double border and no left border we expect the following:
```
╗
║
╝
```
But if we don't render a horizontal edge when the string width is less than 1 we see this:
```

║

```
The string width can't be lower than 0, so we can safely remove the (width < 1) check to create the expected behavior.