### PR TITLE
Introduce triangle border

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -149,6 +149,17 @@ var (
 		BottomLeft:  " ",
 		BottomRight: " ",
 	}
+
+	triangleBorder = Border{
+		Top:         "▼",
+		Bottom:      "▲",
+		Left:        "▶",
+		Right:       "◀",
+		TopLeft:     "◤",
+		TopRight:    "◥",
+		BottomLeft:  "◣",
+		BottomRight: "◢",
+	}
 )
 
 // NormalBorder returns a standard-type border with a normal weight and 90
@@ -194,6 +205,11 @@ func DoubleBorder() Border {
 // color to a hidden border.
 func HiddenBorder() Border {
 	return hiddenBorder
+}
+
+// TriangleBorder returns a border made of triangles.
+func TriangleBorder() Border {
+	return triangleBorder
 }
 
 func (s Style) applyBorder(str string) string {


### PR DESCRIPTION
This looks like this :)

```
◤▼▼▼▼▼▼▼▼◥
▶        ◀
▶  Foo   ◀
▶  Bar   ◀
▶        ◀
◣▲▲▲▲▲▲▲▲◢
```

You could say that's a bit ugly, but such a border unleash its real power when used for styling - for instance - list elements:

```
  Foo
▶ Bar
  Baz
```

In this example, normal elements got a simple `PaddingLeft(2)`, where focus element got `PaddingLeft(1).BorderStyle(lipgloss.TriangleBorder()).BorderLeft(true)`.