### PR TITLE
Fix both GetHorizontalBorderSize and GetVerticalBorderSize

### DIFF
--- a/get.go
+++ b/get.go
@@ -340,16 +340,14 @@ func (s Style) GetBorderRightSize() int {
 // borders contain runes of varying widths, the widest rune is returned. If no
 // border exists on the horizontal edges, 0 is returned.
 func (s Style) GetHorizontalBorderSize() int {
-	b := s.getBorderStyle()
-	return b.GetLeftSize() + b.GetRightSize()
+	return s.GetBorderLeftSize() + s.GetBorderRightSize()
 }
 
 // GetVerticalBorderSize returns the width of the vertical borders. If
 // borders contain runes of varying widths, the widest rune is returned. If no
 // border exists on the vertical edges, 0 is returned.
 func (s Style) GetVerticalBorderSize() int {
-	b := s.getBorderStyle()
-	return b.GetTopSize() + b.GetBottomSize()
+	return s.GetBorderTopSize() + s.GetBorderBottomSize()
 }
 
 // GetInline returns the style's inline setting. If no value is set false is


### PR DESCRIPTION
In both `GetHorizontalBorderSize` and `GetVerticalBorderSize`, computing size directly using `getBorderStyle()` can not take into accounts that some borders ("top", maybe "right", "bottom", whatever...) could have been disabled, leading to incorrect results.

This is well done in each individual `GetBorder[Top|Right|Bottom|Left]Size`like this: https://github.com/charmbracelet/lipgloss/blob/df8b3fa1f20885458615189fa0558c6226be8240/get.go#L303-L305

So this pull request just make use of this correct behavior :)