### PR TITLE
feat: Style.Transform for altering strings at render time

### DIFF
--- a/get.go
+++ b/get.go
@@ -408,6 +408,12 @@ func (s Style) GetFrameSize() (x, y int) {
 	return s.GetHorizontalFrameSize(), s.GetVerticalFrameSize()
 }
 
+// GetTransform returns the transform set on the style. If no transform is set
+// nil is returned.
+func (s Style) GetTransform() func(string) string {
+	return s.getAsTransform(transformKey)
+}
+
 // Returns whether or not the given property is set.
 func (s Style) isSet(k propKey) bool {
 	_, exists := s.rules[k]
@@ -467,6 +473,17 @@ func (s Style) getBorderStyle() Border {
 		return b
 	}
 	return noBorder
+}
+
+func (s Style) getAsTransform(k propKey) func(string) string {
+	v, ok := s.rules[k]
+	if !ok {
+		return nil
+	}
+	if fn, ok := v.(func(string) string); ok {
+		return fn
+	}
+	return nil
 }
 
 // Split a string into lines, additionally returning the size of the widest

--- a/set.go
+++ b/set.go
@@ -544,6 +544,18 @@ func (s Style) StrikethroughSpaces(v bool) Style {
 	return s
 }
 
+// Transform applies a given function to a string at render time, allowing for
+// the string being rendered to be manipuated.
+//
+// Example:
+//
+//	s := NewStyle().Transform(strings.ToUpper)
+//	fmt.Println(s.Render("raow!") // "RAOW!"
+func (s Style) Transform(fn func(string) string) Style {
+	s.set(transformKey, fn)
+	return s
+}
+
 // Renderer sets the renderer for the style. This is useful for changing the
 // renderer for a style that is being used in a different context.
 func (s Style) Renderer(r *Renderer) Style {

--- a/style.go
+++ b/style.go
@@ -73,6 +73,8 @@ const (
 	tabWidthKey
 	underlineSpacesKey
 	strikethroughSpacesKey
+
+	transformKey
 )
 
 // A set of properties.
@@ -225,6 +227,8 @@ func (s Style) Render(strs ...string) string {
 
 		// Do we need to style spaces separately?
 		useSpaceStyler = underlineSpaces || strikethroughSpaces
+
+		transform = s.getAsTransform(transformKey)
 	)
 
 	if len(s.rules) == 0 {
@@ -399,6 +403,10 @@ func (s Style) Render(strs ...string) string {
 	if maxHeight > 0 {
 		lines := strings.Split(str, "\n")
 		str = strings.Join(lines[:min(maxHeight, len(lines))], "\n")
+	}
+
+	if transform != nil {
+		return transform(str)
 	}
 
 	return str

--- a/unset.go
+++ b/unset.go
@@ -305,6 +305,12 @@ func (s Style) UnsetStrikethroughSpaces() Style {
 	return s
 }
 
+// UnsetTransform removes the value set by Transform.
+func (s Style) UnsetTransform() Style {
+	delete(s.rules, transformKey)
+	return s
+}
+
 // UnsetString sets the underlying string value to the empty string.
 func (s Style) UnsetString() Style {
 	s.value = ""


### PR DESCRIPTION
So with this you can basically:

```go
s := NewStyle().Transform(strings.ToUpper)
fmt.Println(s.Render("raow!") // "RAOW!"
```

Some things to consider:

* Should it accept multiple functions?
* Is `Transform` the best name for this?
* Should it ignore ANSI sequences?

Closes #229.