### PR TITLE
test: last tree node is a subtree

### DIFF
--- a/examples/tree/main.go
+++ b/examples/tree/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss/tree"
+)
+
+func main() {
+	fmt.Println(
+		tree.New(
+			"Items",
+			tree.New(
+				"Vegetables",
+				"Lettuce",
+				"Cabbage",
+			),
+			tree.New(
+				"Drinks",
+				"Beer",
+				"Wine",
+				"Whiskey",
+			),
+			"Bread",
+			tree.New(
+				"Meats",
+				"Beef",
+				"Pork",
+				"Chicken",
+			),
+		),
+	)
+}

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -1,88 +1,99 @@
 package tree
 
-import "strings"
+import (
+	"strings"
+)
 
 // Node is a node in a tree.
 type Node interface {
+	Name() string
 	String() string
 	Children() []Node
 }
 
+// StringNode is a node without children.
+type StringNode string
+
+func (StringNode) Children() []Node { return nil }
+func (s StringNode) Name() string   { return string(s) }
+func (s StringNode) String() string { return s.Name() }
+
 // IndentFunc is the function that allow customization of the indentation of
 // the tree.
-type IndentFunc func(n Node, level, index int, last bool) string
+type IndentFunc func(children []Node, prefix string) string
 
-// StringNode implements the Node interface with String data.
-type StringNode struct {
+// TreeNode implements the Node interface with String data.
+type TreeNode struct {
+	name       string
 	indentFunc IndentFunc
-	data       *string
 	children   []Node
 }
 
-func (n StringNode) string(level, index int, last bool) string {
-	var s strings.Builder
-
-	if n.data != nil {
-		if n.indentFunc != nil {
-			s.WriteString(n.indentFunc(n, level, index, last))
-		}
-		s.WriteString(*n.data + "\n")
-	}
-
-	for i, child := range n.children {
-		c := child.(*StringNode)
-		c.indentFunc = n.indentFunc
-		s.WriteString(c.string(level+1, i, i == len(n.children)-1))
-	}
-
-	return s.String()
+// Name returns the root name of this node.
+func (n TreeNode) Name() string {
+	return n.name
 }
 
-func (n StringNode) String() string {
-	return n.string(-1, 0, false)
+func (n TreeNode) String() string {
+	var sb strings.Builder
+	if n.Name() != "" {
+		sb.WriteString(n.Name() + "\n")
+	}
+	sb.WriteString(n.indentFunc(n.children, ""))
+	return sb.String()
 }
 
 // Indent sets the indentation function for a string node / tree.
-func (n *StringNode) Indent(indentFunc IndentFunc) *StringNode {
+func (n *TreeNode) Indent(indentFunc IndentFunc) *TreeNode {
 	n.indentFunc = indentFunc
 	return n
 }
 
 // Children returns the children of a string node.
-func (n StringNode) Children() []Node {
+func (n TreeNode) Children() []Node {
 	return n.children
 }
 
-func defaultIndentFunc(_ Node, level, _ int, last bool) string {
-	var s strings.Builder
+func defaultIndentFunc(children []Node, prefix string) string {
+	var sb strings.Builder
+	for i, info := range children {
+		var treePrefix string
+		var branch string
 
-	if level >= 0 {
-		s.WriteString(strings.Repeat("│  ", level))
+		if i == len(children)-1 {
+			treePrefix = "└──"
+			branch = "   "
+		} else {
+			treePrefix = "├──"
+			branch = "│  "
+		}
+
+		sb.WriteString(prefix + treePrefix + " " + info.Name() + "\n")
+		if len(info.Children()) > 0 {
+			sb.WriteString(defaultIndentFunc(info.Children(), prefix+branch))
+		}
 	}
-
-	if last {
-		s.WriteString("└── ")
-	} else {
-		s.WriteString("├── ")
-	}
-
-	return s.String()
+	return sb.String()
 }
 
 // New returns a new tree.
-func New(data ...any) *StringNode {
+func New(name string, data ...any) *TreeNode {
 	var children []Node
-
 	for _, d := range data {
 		switch d := d.(type) {
+		case *TreeNode:
+			children = append(children, d)
+		case StringNode:
+			children = append(children, d)
 		case *StringNode:
 			children = append(children, d)
 		case string:
-			children = append(children, &StringNode{data: &d, indentFunc: defaultIndentFunc})
+			s := StringNode(d)
+			children = append(children, &s)
 		}
 	}
-
-	return &StringNode{
+	return &TreeNode{
+		name:       name,
 		children:   children,
 		indentFunc: defaultIndentFunc,
 	}

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -14,8 +14,14 @@ type Node interface {
 // StringNode is a node without children.
 type StringNode string
 
+// Children conforms with Node.
+// StringNodes have no children.
 func (StringNode) Children() []Node { return nil }
-func (s StringNode) Name() string   { return string(s) }
+
+// Name conforms with Node.
+// Returns the value of the string itself.
+func (s StringNode) Name() string { return string(s) }
+
 func (s StringNode) String() string { return s.Name() }
 
 // IndentFunc is the function that allow customization of the indentation of
@@ -23,16 +29,14 @@ func (s StringNode) String() string { return s.Name() }
 type IndentFunc func(children []Node, prefix string) string
 
 // TreeNode implements the Node interface with String data.
-type TreeNode struct {
+type TreeNode struct { //nolint:revive
 	name       string
 	indentFunc IndentFunc
 	children   []Node
 }
 
 // Name returns the root name of this node.
-func (n TreeNode) Name() string {
-	return n.name
-}
+func (n TreeNode) Name() string { return n.name }
 
 func (n TreeNode) String() string {
 	var sb strings.Builder

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -72,7 +72,14 @@ func defaultIndentFunc(children []Node, prefix string) string {
 			branch = "│  "
 		}
 
-		sb.WriteString(prefix + treePrefix + " " + info.Name() + "\n")
+		for i, line := range strings.Split(info.Name(), "\n") {
+			if i == 0 {
+				sb.WriteString(prefix + treePrefix + " " + line + "\n")
+				continue
+			}
+			sb.WriteString(prefix + branch + " " + line + "\n")
+		}
+
 		if len(info.Children()) > 0 {
 			sb.WriteString(defaultIndentFunc(info.Children(), prefix+branch))
 		}

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -37,6 +37,36 @@ func TestTree(t *testing.T) {
 	}
 }
 
+func TestTreeLastNodeIsSubTree(t *testing.T) {
+	tree := New(
+		"Foo",
+		"Bar",
+		New(
+			"Qux",
+			"Quux",
+			New(
+				"Foo",
+				"Bar",
+			),
+			"Quuux",
+		),
+	)
+
+	expected := strings.TrimPrefix(`
+├── Foo
+└─── Bar
+   ├── Qux
+   ├── Quux
+   │  ├── Foo
+   │  └── Bar
+   └── Quuux
+`, "\n")
+
+	if tree.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s\n", expected, tree)
+	}
+}
+
 func TestTreeNil(t *testing.T) {
 	tree := New(
 		nil,

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -7,12 +7,13 @@ import (
 
 func TestTree(t *testing.T) {
 	tree := New(
+		"",
 		"Foo",
-		"Bar",
 		New(
+			"Bar",
 			"Qux",
-			"Quux",
 			New(
+				"Quux",
 				"Foo",
 				"Bar",
 			),
@@ -37,14 +38,64 @@ func TestTree(t *testing.T) {
 	}
 }
 
+func TestTreeRoot(t *testing.T) {
+	tree := New(
+		"The Root",
+		"Foo",
+		New(
+			"Bar",
+			"Qux",
+			"Quuux",
+		),
+		"Baz",
+	)
+
+	expected := strings.TrimPrefix(`
+The Root
+├── Foo
+├── Bar
+│  ├── Qux
+│  └── Quuux
+└── Baz
+`, "\n")
+
+	if tree.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s\n", expected, tree)
+	}
+}
+
+func TestTreeStartsWithSubtree(t *testing.T) {
+	tree := New(
+		"",
+		New(
+			"Bar",
+			"Qux",
+			"Quuux",
+		),
+		"Baz",
+	)
+
+	expected := strings.TrimPrefix(`
+├── Bar
+│  ├── Qux
+│  └── Quuux
+└── Baz
+`, "\n")
+
+	if tree.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s\n", expected, tree)
+	}
+}
+
 func TestTreeLastNodeIsSubTree(t *testing.T) {
 	tree := New(
+		"",
 		"Foo",
-		"Bar",
 		New(
+			"Bar",
 			"Qux",
-			"Quux",
 			New(
+				"Quux",
 				"Foo",
 				"Bar",
 			),
@@ -54,7 +105,7 @@ func TestTreeLastNodeIsSubTree(t *testing.T) {
 
 	expected := strings.TrimPrefix(`
 ├── Foo
-└─── Bar
+└── Bar
    ├── Qux
    ├── Quux
    │  ├── Foo
@@ -69,13 +120,13 @@ func TestTreeLastNodeIsSubTree(t *testing.T) {
 
 func TestTreeNil(t *testing.T) {
 	tree := New(
+		"",
 		nil,
-		"Bar",
 		New(
+			"Bar",
 			"Qux",
-			"Quux",
 			New(
-				nil,
+				"Quux",
 				"Bar",
 			),
 			"Quuux",
@@ -97,23 +148,36 @@ func TestTreeNil(t *testing.T) {
 	}
 }
 
+func arrowIndent(children []Node, prefix string) string {
+	var sb strings.Builder
+	if prefix == "" {
+		prefix = "-> "
+	}
+	for _, node := range children {
+		sb.WriteString(prefix + node.Name() + "\n")
+		if len(node.Children()) > 0 {
+			sb.WriteString(arrowIndent(node.Children(), prefix+"-> "))
+		}
+	}
+	return sb.String()
+}
+
 func TestTreeCustom(t *testing.T) {
 	tree := New(
+		"",
 		"Foo",
-		"Bar",
 		New(
+			"Bar",
 			"Qux",
-			"Quux",
 			New(
+				"Quux",
 				"Foo",
 				"Bar",
 			),
 			"Quuux",
 		),
 		"Baz",
-	).Indent(func(t Node, level, index int, last bool) string {
-		return strings.Repeat("-> ", level+1)
-	})
+	).Indent(arrowIndent)
 
 	expected := strings.TrimPrefix(`
 -> Foo

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -195,3 +195,43 @@ func TestTreeCustom(t *testing.T) {
 		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s\n", expected, tree)
 	}
 }
+
+func TestTreeMultilineNode(t *testing.T) {
+	tree := New(
+		"Multiline\nRoot\nNode",
+		"Foo",
+		New(
+			"Bar",
+			"Qux\nLine 2\nLine 3\nLine 4",
+			New(
+				"Quux",
+				"Foo",
+				"Bar",
+			),
+			"Quuux",
+		),
+		"Baz\nLine 2",
+	)
+
+	expected := strings.TrimPrefix(`
+Multiline
+Root
+Node
+├── Foo
+├── Bar
+│  ├── Qux
+│  │   Line 2
+│  │   Line 3
+│  │   Line 4
+│  ├── Quux
+│  │  ├── Foo
+│  │  └── Bar
+│  └── Quuux
+└── Baz
+    Line 2
+`, "\n")
+
+	if tree.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s\n", expected, tree)
+	}
+}

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -163,18 +163,19 @@ func arrowIndent(children []Node, prefix string) string {
 }
 
 func TestTreeCustom(t *testing.T) {
+	quuux := StringNode("Quuux")
 	tree := New(
 		"",
 		"Foo",
 		New(
 			"Bar",
-			"Qux",
+			StringNode("Qux"),
 			New(
 				"Quux",
 				"Foo",
 				"Bar",
 			),
-			"Quuux",
+			&quuux,
 		),
 		"Baz",
 	).Indent(arrowIndent)


### PR DESCRIPTION
this is currently resulting in 


```
        ├── Foo
        ├── Bar
        │  ├── Qux
        │  ├── Quux
        │  │  ├── Foo
        │  │  └── Bar
        │  └── Quuux
```

not sure how to best fix it, though... 


I think maybe the api needs be a bit different, e.g., instead of:

```go
New("foo", New("bar", "zaz", New("aa"))
```

something like:

```go
New(New("foo", "bar", New("zaz", "aa")))
```

This is also what I was kinda expecting: the first param is the node name, and the remaining are its children.

It would also make a bit more sense in internal semantics, as currently the children of a node can be either the next nodes or a subtree, which IMHO is the thing that should be called children.

thoughts?

