### PR TITLE
Added option to render styles with optional separator

### DIFF
--- a/style.go
+++ b/style.go
@@ -110,6 +110,12 @@ func joinString(strs ...string) string {
 	return strings.Join(strs, " ")
 }
 
+// joinString joins a list of strings into a single string separated with a
+// space.
+func joinStringWithSeparator(separator string, strs ...string) string {
+	return strings.Join(strs, separator)
+}
+
 // SetString sets the underlying string value for this style. To render once
 // the underlying string is set, use the Style.String. This method is
 // a convenience for cases when having a stringer implementation is handy, such
@@ -177,6 +183,11 @@ func (s Style) Inherit(i Style) Style {
 
 // Render applies the defined style formatting to a given string.
 func (s Style) Render(strs ...string) string {
+	return s.RenderWithSeparator(" ", strs...)
+}
+
+// Render applies the defined style formatting to a given string.
+func (s Style) RenderWithSeparator(separator string, strs ...string) string {
 	if s.r == nil {
 		s.r = renderer
 	}
@@ -185,7 +196,7 @@ func (s Style) Render(strs ...string) string {
 	}
 
 	var (
-		str = joinString(strs...)
+		str = joinStringWithSeparator(separator, strs...)
 
 		p            = s.r.ColorProfile()
 		te           = p.String()


### PR DESCRIPTION
The problem with the current implementation is that you cannot modify the rendering of the styles when you have multiple lines to render.
The only way to render multilines is having "\n" between the lines. That is not only cumbersome, but has bugged view with extra space character at the start of every new line.
This PR fixes this.

this is how it looks when rendering code 
`
lines = []string{
		"first line",
		"\n",
		"second line",
	}
`
![image](https://github.com/charmbracelet/lipgloss/assets/6891009/8abf5c7c-43e0-4bc7-a0bf-1454056e56ba)


this is how it looks when rendering PR code 
`
lines = []string{
		"first line",
		"second line",
	}
...
style.RenderWithSeparator("\n", lines...),
`
![image](https://github.com/charmbracelet/lipgloss/assets/6891009/fd4b1e65-dcd7-494b-aab7-c25732910ea1)


