### PR TITLE
fix: transform shouldn't operate on ANSI sequences

### DIFF
--- a/style.go
+++ b/style.go
@@ -231,6 +231,10 @@ func (s Style) Render(strs ...string) string {
 		transform = s.getAsTransform(transformKey)
 	)
 
+	if transform != nil {
+		str = transform(str)
+	}
+
 	if len(s.rules) == 0 {
 		return s.maybeConvertTabs(str)
 	}
@@ -406,10 +410,6 @@ func (s Style) Render(strs ...string) string {
 		if len(lines) > 0 {
 			str = strings.Join(lines[:height], "\n")
 		}
-	}
-
-	if transform != nil {
-		return transform(str)
 	}
 
 	return str

--- a/style_test.go
+++ b/style_test.go
@@ -410,11 +410,19 @@ func TestStringTransform(t *testing.T) {
 		fn       func(string) string
 		expected string
 	}{
+		// No-op.
+		{
+			"hello",
+			func(s string) string { return s },
+			"hello",
+		},
+		// Uppercase.
 		{
 			"raow",
 			strings.ToUpper,
 			"RAOW",
 		},
+		// English and Chinese.
 		{
 			"The quick brown 狐 jumped over the lazy 犬",
 			func(s string) string {
@@ -433,9 +441,10 @@ func TestStringTransform(t *testing.T) {
 			"犬 yzal eht revo depmuj 狐 nworb kciuq ehT",
 		},
 	} {
-		res := NewStyle().Transform(tc.fn).Render(tc.input)
-		if res != tc.expected {
-			t.Errorf("Test #%d:\nExpected: %q\nGot: %q", i+1, tc.expected, res)
+		res := NewStyle().Bold(true).Transform(tc.fn).Render(tc.input)
+		expected := "\x1b[1m" + tc.expected + "\x1b[0m"
+		if res != expected {
+			t.Errorf("Test #%d:\nExpected: %q\nGot:      %q", i+1, expected, res)
 		}
 	}
 }


### PR DESCRIPTION
This patch fixes a bug where string transforms were applied after styling, potentially altering ANSI sequences.