### PR TITLE
feat: Update new border info api (show information on bottom border)

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -365,8 +365,24 @@ func (s Style) applyBorder(str string) string {
 
 	// Render bottom
 	if hasBottom {
-		bottom := renderHorizontalEdge(border.BottomLeft, border.Bottom, border.BottomRight, width)
-		bottom = s.styleBorder(bottom, bottomFG, bottomBG)
+		bottom := ""
+		info := s.GetBorderInfoTitle()
+		
+		// Render border info if user set
+		if len(strings.TrimSpace(info)) > 0 {
+			infoStyle := s.GetBorderInfoStyle().Copy().MaxWidth(width)
+			if infoStyle.GetHorizontalPadding() == 0 {
+				infoStyle = infoStyle.Padding(0, 1)
+			}
+
+			beforeInfo, afterInfo := renderBorderContent(info, infoStyle, border, width)
+			bottom = s.styleBorder(beforeInfo, bottomFG, bottomBG) +
+					 infoStyle.Render(info) +
+					 s.styleBorder(afterInfo, bottomFG, bottomBG)
+		} else {
+			bottom = renderHorizontalEdge(border.BottomLeft, border.Bottom, border.BottomRight, width)
+			bottom = s.styleBorder(bottom, bottomFG, bottomBG)
+		}
 		out.WriteRune('\n')
 		out.WriteString(bottom)
 	}
@@ -399,6 +415,29 @@ func renderHorizontalEdge(left, middle, right string, width int) string {
 	out.WriteString(right)
 
 	return out.String()
+}
+
+// Render border info or border ttitle.
+func renderBorderContent(content string, contentStyle Style, border Border, width int) (beforeContent, afterContent string) {
+	const sideCount = 2
+
+	contentLen := contentStyle.GetHorizontalFrameSize() + ansi.StringWidth(content)
+	beforeContent = border.BottomLeft
+	afterContent = border.BottomRight
+
+	switch contentStyle.GetAlignHorizontal() {
+	case Right:
+		beforeContent = border.BottomLeft + strings.Repeat(border.Top, max(0, width-1-contentLen))
+	case Center:
+		noContentLen := width - 1 - contentLen
+		noContentLen2 := noContentLen / sideCount
+		beforeContent = border.BottomLeft + strings.Repeat(border.Top, max(0, noContentLen2))
+		afterContent = strings.Repeat(border.Top, max(0, noContentLen-noContentLen2)) + border.BottomRight
+	case Left:
+		afterContent = strings.Repeat(border.Top, max(0, width-1-contentLen)) + border.BottomRight
+	}
+
+	return beforeContent, afterContent
 }
 
 // Apply foreground and background styling to a border.

--- a/get.go
+++ b/get.go
@@ -414,6 +414,14 @@ func (s Style) GetTransform() func(string) string {
 	return s.getAsTransform(transformKey)
 }
 
+func (s Style) GetBorderInfoStyle() Style {
+	return s.getAsStyle(borderInfoStyleKey)
+}
+
+func (s Style) GetBorderInfoTitle() string {
+	return s.getAsString(borderInfoKey)
+}
+
 // Returns whether or not the given property is set.
 func (s Style) isSet(k propKey) bool {
 	_, exists := s.rules[k]
@@ -484,6 +492,24 @@ func (s Style) getAsTransform(k propKey) func(string) string {
 		return fn
 	}
 	return nil
+}
+
+func (s Style) getAsString(k propKey) string {
+	if v, ok := s.rules[k]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func (s Style) getAsStyle(k propKey) Style {
+	if v, ok := s.rules[k]; ok {
+		if s, ok := v.(Style); ok {
+			return s
+		}
+	}
+	return NewStyle()
 }
 
 // Split a string into lines, additionally returning the size of the widest

--- a/set.go
+++ b/set.go
@@ -462,6 +462,18 @@ func (s Style) BorderLeftBackground(c TerminalColor) Style {
 	return s
 }
 
+// BorderInfoStyle set border info style
+func (s Style) BorderInfoStyle(style Style) Style {
+	s.set(borderInfoStyleKey, style)
+	return s
+}
+
+// BorderInfo set border info
+func (s Style) BorderInfo(info string) Style {
+	s.set(borderInfoKey, info)
+	return s
+}
+
 // Inline makes rendering output one line and disables the rendering of
 // margins, padding and borders. This is useful when you need a style to apply
 // only to font rendering and don't want it to change any physical dimensions.

--- a/style.go
+++ b/style.go
@@ -65,6 +65,9 @@ const (
 	borderBottomBackgroundKey
 	borderLeftBackgroundKey
 
+	borderInfoStyleKey
+	borderInfoKey
+
 	inlineKey
 	maxWidthKey
 	maxHeightKey


### PR DESCRIPTION
This update is based on https://github.com/charmbracelet/lipgloss/pull/97

I updated to allow the use of Chinese, Japanese, etc. (The original layout has problems when using these characters)

This function can be used to generate titles and info
- `func renderBorderContent(content string, contentStyle Style, border Border, width int)`

My English is not very good and I am not sure how to name those variables. 
Please feel free to tell me if you need to change the variable names or anything!
If necessary, I can also create a PR to make border title apply this function

I really hope this can be put into release together with the title!

![image](https://github.com/charmbracelet/lipgloss/assets/107802416/47575816-e06d-4ab5-850d-61abcc8d7db0)
![image](https://github.com/charmbracelet/lipgloss/assets/107802416/13ecf062-1edf-48f8-886d-2f85acc8d461)
![image](https://github.com/charmbracelet/lipgloss/assets/107802416/d6d7cbe4-5ad1-42cd-a9ec-2328cb7c0e52)