### PR TITLE
feat: support inferring the color profile from terminfo dbs

### DIFF
--- a/env.go
+++ b/env.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/x/exp/term"
+	"github.com/xo/terminfo"
 )
 
 // DetectColorProfile returns the color profile based on the terminal output,
@@ -131,6 +132,28 @@ func envColorProfile(env map[string]string) (p Profile) {
 	}
 	if strings.Contains(term, "ansi") {
 		setProfile(ANSI)
+	}
+
+	if ti, err := terminfo.Load(term); err == nil {
+		extbools := ti.ExtBoolCapsShort()
+		if _, ok := extbools["RGB"]; ok {
+			setProfile(TrueColor)
+		}
+
+		if _, ok := extbools["Tc"]; ok {
+			setProfile(TrueColor)
+		}
+
+		nums := ti.NumCapsShort()
+		if colors, ok := nums["colors"]; ok {
+			if colors >= 0x1000000 {
+				setProfile(TrueColor)
+			} else if colors >= 0x100 {
+				setProfile(ANSI256)
+			} else if colors >= 0x10 {
+				setProfile(ANSI)
+			}
+		}
 	}
 
 	return

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/charmbracelet/x/exp/term v0.0.0-20240425164147-ba2a9512b05f
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/rivo/uniseg v0.4.7
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e
 	golang.org/x/sys v0.19.0
 )
 
 require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 )


### PR DESCRIPTION
This will try to load the terminal terminfo database and infer the color profile supported by the terminal.