### PR TITLE
chore(docs): doc updates with regard to style.Copy() deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
     <a href="https://pkg.go.dev/github.com/charmbracelet/lipgloss?tab=doc"><img src="https://godoc.org/github.com/golang/gddo?status.svg" alt="GoDoc"></a>
     <a href="https://github.com/charmbracelet/lipgloss/actions"><img src="https://github.com/charmbracelet/lipgloss/workflows/build/badge.svg" alt="Build Status"></a>
     <a href="https://www.phorm.ai/query?projectId=a0e324b6-b706-4546-b951-6671ea60c13f"><img src="https://stuff.charm.sh/misc/phorm-badge.svg" alt="phorm.ai"></a>
-    
 </p>
 
 Style definitions for nice terminal layouts. Built with TUIs in mind.
@@ -226,12 +225,15 @@ For more on borders see [the docs][docs].
 
 ## Copying Styles
 
-Just use assignment
+Just use assignment:
 
 ```go
-var style = lipgloss.NewStyle().Foreground(lipgloss.Color("219"))
+style := lipgloss.NewStyle().Foreground(lipgloss.Color("219"))
 
-var wildStyle = style.Blink(true)
+copiedStyle := style // this is a true copy
+
+wildStyle := style.Blink(true) // this is also true copy, with blink added
+
 ```
 
 Since `Style` data structures contains only primitive types, assigning a style

--- a/style.go
+++ b/style.go
@@ -189,7 +189,7 @@ func (s Style) String() string {
 
 // Copy returns a copy of this style, including any underlying string values.
 //
-// Deprecated: Copy is deprecated and will be removed in a future release.
+// Deprecated: to copy just use assignment (i.e. a := b). All methods also return a new style.
 func (s Style) Copy() Style {
 	return s
 }


### PR DESCRIPTION
Small update here mostly to tell people how to resolve deprecation warnings in-editor.
