### PR TITLE
fix: Change the propkeys from int to int64

### DIFF
--- a/style.go
+++ b/style.go
@@ -11,7 +11,7 @@ import (
 const tabWidthDefault = 4
 
 // Property for a key.
-type propKey int
+type propKey int64
 
 // Available properties.
 const (
@@ -78,7 +78,7 @@ const (
 )
 
 // props is a set of properties.
-type props int
+type props int64
 
 // set sets a property.
 func (p props) set(k propKey) props {


### PR DESCRIPTION
 When I create binaries for each OS using goreleaser, the propKeys
generates an int overflow since the iota duplicates for each propKey

This commit changes the int type to works well with binaries generated for arm and i386 archs.