### PR TITLE
Feat: Overlay string on existing strings, add overlay stack to style for rendering

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -62,6 +62,7 @@ github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
+github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=

--- a/examples/layout/main.go
+++ b/examples/layout/main.go
@@ -298,11 +298,17 @@ func main() {
 			historyC = "In 1524, Henry VIII, King of England, received a “box of marmalade” from Mr. Hull of Exeter. This was probably marmelada, a solid quince paste from Portugal, still made and sold in southern Europe today. It became a favourite treat of Anne Boleyn and her ladies in waiting."
 		)
 
+		overwriteStyle := lipgloss.NewStyle().Background(lipgloss.Color("#ff0000")).Width(15).Height(16)
+		overwrite := lipgloss.NewStyle().Background(lipgloss.Color("#ff0000")).Width(15).Height(16).Render("sorry to interrupt, but...")
+		overwrite2 := overwriteStyle.Background(lipgloss.Color("#00ff00")).
+			Foreground(lipgloss.Color("#000000")).Width(8).Height(8).Render("more text for interruptions")
+
+		styledHistoryA := historyStyle.Align(lipgloss.Right).Render(historyA)
 		doc.WriteString(lipgloss.JoinHorizontal(
 			lipgloss.Top,
-			historyStyle.Align(lipgloss.Right).Render(historyA),
+			lipgloss.OverlayString(5, 5, styledHistoryA, overwrite),
 			historyStyle.Align(lipgloss.Center).Render(historyB),
-			historyStyle.MarginRight(0).Render(historyC),
+			historyStyle.MarginRight(0).SetString(historyC).AddOverlay(3, 3, overwrite).AddOverlay(2, 2, overwrite2).Render(),
 		))
 
 		doc.WriteString("\n\n")

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,14 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
+github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/style_test.go
+++ b/style_test.go
@@ -404,6 +404,66 @@ func TestTabConversion(t *testing.T) {
 	requireEqual(t, "[\t]", s.Render("[\t]"))
 }
 
+func TestStringOverlay(t *testing.T) {
+	line := "ooo"
+	background := JoinVertical(Left, line, line, line)
+	result := OverlayString(1, 1, background, "x")
+	expected := "ooo\noxo\nooo"
+	if result != expected {
+		t.Errorf("Basic string overlay is not overlaying as expected.\n\nExpected:\n%s\n\nActual:\n%s", expected, result)
+	}
+}
+
+func TestStringOverlay_RendersOverhangProperly(t *testing.T) {
+	bgLine := "ooo"
+	background := JoinVertical(Left, bgLine, bgLine, bgLine)
+	fgLine := "xxx"
+	foreground := JoinVertical(Left, fgLine, fgLine, fgLine)
+	result := OverlayString(1, 1, background, foreground)
+	expected := "ooo\noxx\noxx"
+	if result != expected {
+		t.Errorf("Overhanging string overlay is not overlaying as expected.\n\nExpected:\n%s\n\nActual:\n%s", expected, result)
+	}
+}
+
+func TestStringOverlay_RendersNegativeStartingPointsProperly(t *testing.T) {
+	bgLine := "ooo"
+	background := JoinVertical(Left, bgLine, bgLine, bgLine)
+	fgLine := "123"
+	foreground := JoinVertical(Left, fgLine, fgLine, fgLine)
+	result := OverlayString(-1, -1, background, foreground)
+	expected := "23o\n23o\nooo"
+	if result != expected {
+		t.Errorf("Overhanging string overlay is not overlaying as expected.\n\nExpected:\n%s\n\nActual:\n%s", expected, result)
+	}
+}
+
+func TestStringOverlay_ColorBackground(t *testing.T) {
+	line := "ooo"
+	middleLine := NewStyle().Foreground(Color("#ff0000")).Render(line)
+	background := JoinVertical(Left, line, middleLine, line)
+
+	result := OverlayString(1, 1, background, "x")
+
+	colorO := NewStyle().Foreground(Color("#ff0000")).Render("o")
+	expectedMiddleLine := colorO + "x" + colorO
+	expected := "ooo\n" + expectedMiddleLine + "\nooo"
+	if result != expected {
+		t.Errorf("String overlay is not overlaying on colored background as expected.\n\nExpected:\n%s\n\nActual:\n%s", expected, result)
+	}
+}
+
+func TestStyleString_AddOverlay_PushesItemToBackingList(t *testing.T) {
+	line := "ooo"
+	background := JoinVertical(Left, line, line, line)
+	s := NewStyle().SetString(background).AddOverlay(1, 1, "x").AddOverlay(2, 2, "y")
+	expected := 2
+	result := len(s.overlays)
+	if result != expected {
+		t.Errorf("Basic string overlay is not adding to backing overlay list as expected.\n\nExpected length:\n%d\n\nActual length:\n%d", expected, result)
+	}
+}
+
 func TestStringTransform(t *testing.T) {
 	for i, tc := range []struct {
 		input    string


### PR DESCRIPTION
Base logic shamelessly stolen from [mrusme](https://github.com/mrusme/neonmodem/commit/cd7b173cc7b9db8224d4cf944c6da5391516767d), though adapted for more general purposes and added tests.