### PR TITLE
Fixed UnderlineSpaces and StrikethroughSpaces

### DIFF
--- a/style.go
+++ b/style.go
@@ -271,15 +271,18 @@ func (s Style) Render(strs ...string) string {
 		maxWidth        = s.getAsInt(maxWidthKey)
 		maxHeight       = s.getAsInt(maxHeightKey)
 
-		underlineSpaces     = underline && s.getAsBool(underlineSpacesKey, true)
-		strikethroughSpaces = strikethrough && s.getAsBool(strikethroughSpacesKey, true)
+        us = s.getAsBool(underlineSpacesKey, false)
+        ss = s.getAsBool(strikethroughSpacesKey, false)
+
+		underlineSpaces     = us || (underline && s.getAsBool(underlineSpacesKey, true))
+		strikethroughSpaces = ss || (strikethrough && s.getAsBool(strikethroughSpacesKey, true))
 
 		// Do we need to style whitespace (padding and space outside
 		// paragraphs) separately?
 		styleWhitespace = reverse
 
 		// Do we need to style spaces separately?
-		useSpaceStyler = underlineSpaces || strikethroughSpaces
+		useSpaceStyler = (underline && !underlineSpaces) || (strikethrough && !strikethroughSpaces) || underlineSpaces || strikethroughSpaces
 
 		transform = s.getAsTransform(transformKey)
 	)


### PR DESCRIPTION
fixes #113 

Fixed:
- [x] UnderlineSpaces and StrikethroughSpaces don't show up without Underline and Strikethrough respectively
- [x] UnderlineSpaces and StrikethroughSpaces show up when explicitly set to false, while Underline and Strikethrough are set to true respectively