### PR TITLE
feat: deprecate Style.ColorWhitespace

### DIFF
--- a/set.go
+++ b/set.go
@@ -321,6 +321,8 @@ func (s Style) PaddingBottom(i int) Style {
 // applied to the padding. This is true by default as it's more than likely the
 // desired and expected behavior, but it can be disabled for certain graphic
 // effects.
+//
+// Deprecated: Just use margins and padding.
 func (s Style) ColorWhitespace(v bool) Style {
 	s.set(colorWhitespaceKey, v)
 	return s


### PR DESCRIPTION
You can get the exact same effect with margins and padding. This basically finishes the job started in #311.