### PR TITLE
fix: Deprecate UnsetBorderTopBackgroundColor in favor of UnsetBorderTopBackground

### DIFF
--- a/unset.go
+++ b/unset.go
@@ -249,7 +249,15 @@ func (s Style) UnsetBorderBackground() Style {
 
 // UnsetBorderTopBackgroundColor removes the top border background color rule,
 // if set.
+//
+// Deprecated: This function simply calls Style.UnsetBorderTopBackground.
 func (s Style) UnsetBorderTopBackgroundColor() Style {
+	return s.UnsetBorderTopBackground()
+}
+
+// UnsetBorderTopBackground removes the top border background color rule,
+// if set.
+func (s Style) UnsetBorderTopBackground() Style {
 	s.unset(borderTopBackgroundKey)
 	return s
 }


### PR DESCRIPTION
This looks like a looong standing typo :)

This is the only one method ending by "Color". To avoid breaking changes, i've just copy/paste to a new one, directly call this new one, and add a deprecation notice.