### PR TITLE
feat: List "items" method should return instead of setting items

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,12 +491,12 @@ style1 := lipgloss.NewStyle().Foreground(lipgloss.Color("99")).MarginRight(1)
 style2 := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).MarginRight(1)
 
 t := tree.New().
-	Items(
+	Item(
 		"Glossier",
 		"Claire’s Boutique",
 		tree.New().
 			Root("Nyx").
-			Items("Qux", "Quux").
+			Item("Qux", "Quux").
 			EnumeratorStyle(style2),
 		"Mac",
 		"Milk",

--- a/list/list.go
+++ b/list/list.go
@@ -49,7 +49,7 @@ type List struct{ tree *tree.Tree }
 // anything you want, really.
 func New(items ...any) *List {
 	l := &List{tree: tree.New()}
-	return l.Items(items...).Enumerator(Bullet)
+	return l.Item(items...).Enumerator(Bullet)
 }
 
 // Items represents the list items.
@@ -175,31 +175,26 @@ func (l *List) ItemStyleFunc(f StyleFunc) *List {
 	return l
 }
 
-// Item appends an item to the list.
+// Item appends an item(s) to the list.
 //
 //	l := list.New().
 //		Item("Foo").
-//		Item("Bar").
-//		Item("Baz")
-func (l *List) Item(item any) *List {
-	switch item := item.(type) {
-	case *List:
-		l.tree.Child(item.tree)
-	default:
-		l.tree.Child(item)
+//		Item("Bar", "Baz")
+func (l *List) Item(items ...any) *List {
+	for _, item := range items {
+		switch item := item.(type) {
+		case *List:
+			l.tree.Child(item.tree)
+		default:
+			l.tree.Child(item)
+		}
 	}
 	return l
 }
 
-// Items appends multiple items to the list.
-//
-//	l := list.New().
-//		Items("Foo", "Bar", "Baz"),
-func (l *List) Items(items ...any) *List {
-	for _, item := range items {
-		l.Item(item)
-	}
-	return l
+// Items returns the items of the list.
+func (l *List) Items() Items {
+	return l.tree.Children()
 }
 
 // Enumerator sets the list enumerator.

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -28,9 +28,10 @@ func TestList(t *testing.T) {
 	assertEqual(t, expected, l.String())
 }
 
-func TestListItems(t *testing.T) {
+func TestListItem(t *testing.T) {
 	l := list.New().
-		Items([]string{"Foo", "Bar", "Baz"})
+		Item("Foo").
+		Item([]string{"Bar", "Baz"})
 
 	expected := `
 • Foo
@@ -38,6 +39,30 @@ func TestListItems(t *testing.T) {
 • Baz
 	`
 	assertEqual(t, expected, l.String())
+}
+
+func TestListItems(t *testing.T) {
+	strs := []string{"Foo", "Bar", "Baz"}
+
+	items := list.New(strs).Items()
+
+	length := items.Length()
+	expectedLength := 3
+	if length != expectedLength {
+		t.Fatalf("expected:%d got:%d", expectedLength, length)
+	}
+
+	for i := 0; i < 3; i++ {
+		item := items.At(i)
+		if item.Value() != strs[i] {
+			t.Fatalf("expected:%s got:%s", strs[i], item.Value())
+		}
+	}
+
+	item := items.At(4)
+	if item != nil {
+		t.Fatalf("expected:%v got:%v", nil, item)
+	}
 }
 
 func TestSublist(t *testing.T) {
@@ -508,11 +533,11 @@ LXXXVIII. Foo
 }
 
 func TestSubListItems(t *testing.T) {
-	l := list.New().Items(
+	l := list.New().Item(
 		"S",
-		list.New().Items("neovim", "vscode"),
+		list.New().Item("neovim", "vscode"),
 		"HI",
-		list.New().Items([]string{"vim", "doom emacs"}),
+		list.New().Item([]string{"vim", "doom emacs"}),
 		"Parent 2",
 		list.New().Item("I like fuzzy socks"),
 	)

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -118,7 +118,7 @@ func (t *Tree) String() string {
 	return t.ensureRenderer().render(t, true, "")
 }
 
-// Child adds a child to this tree.
+// Child adds a child(ren) to this tree.
 //
 // If a Child Tree is passed without a root, it will be parented to it's sibling
 // child (auto-nesting).


### PR DESCRIPTION
The same way `tree` has a `Child` method to set child(ren) and a `Children` method to return children, `list` method `Items` should return items.

Please, take into account that:
- without this, there is currently no other methods to get list items
- list `Item`ans `Items` methods are currently redundants, as they both set list item(s)
- this is a breaking change, but list component is not officially released

Fix https://github.com/charmbracelet/lipgloss/issues/320