### PR TITLE
fix(example): remove deprecated NewRenderer

### DIFF
--- a/examples/table/chess/main.go
+++ b/examples/table/chess/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -10,8 +9,7 @@ import (
 )
 
 func main() {
-	re := lipgloss.NewRenderer(os.Stdout)
-	labelStyle := re.NewStyle().Foreground(lipgloss.Color("241"))
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 
 	board := [][]string{
 		{"♜", "♞", "♝", "♛", "♚", "♝", "♞", "♜"},

--- a/examples/table/languages/main.go
+++ b/examples/table/languages/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
@@ -15,13 +14,11 @@ const (
 )
 
 func main() {
-	re := lipgloss.NewRenderer(os.Stdout)
-
 	var (
 		// HeaderStyle is the lipgloss style used for the table headers.
-		HeaderStyle = re.NewStyle().Foreground(purple).Bold(true).Align(lipgloss.Center)
+		HeaderStyle = lipgloss.NewStyle().Foreground(purple).Bold(true).Align(lipgloss.Center)
 		// CellStyle is the base lipgloss style used for the table rows.
-		CellStyle = re.NewStyle().Padding(0, 1).Width(14)
+		CellStyle = lipgloss.NewStyle().Padding(0, 1).Width(14)
 		// OddRowStyle is the lipgloss style used for odd-numbered table rows.
 		OddRowStyle = CellStyle.Foreground(gray)
 		// EvenRowStyle is the lipgloss style used for even-numbered table rows.

--- a/examples/table/mindy/main.go
+++ b/examples/table/mindy/main.go
@@ -2,16 +2,14 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
 )
 
 func main() {
-	re := lipgloss.NewRenderer(os.Stdout)
-	labelStyle := re.NewStyle().Width(3).Align(lipgloss.Right)
-	swatchStyle := re.NewStyle().Width(6)
+	labelStyle := lipgloss.NewStyle().Width(3).Align(lipgloss.Right)
+	swatchStyle := lipgloss.NewStyle().Width(6)
 
 	data := [][]string{}
 	for i := 0; i < 13; i += 8 {


### PR DESCRIPTION
the table examples weren't running as they were still using the `lipgloss.NewRenderer` which no longer exists in the `beta` branch