### PR TITLE
Initializing t.data with new content instead of leaving it as nil

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -84,7 +84,7 @@ func New() *Table {
 
 // ClearRows clears the table rows.
 func (t *Table) ClearRows() *Table {
-	t.data = nil
+	t.data = NewStringData()
 	return t
 }
 


### PR DESCRIPTION
leaving t.data as nil causes a panic if the table is re-rendered again without adding new rows