### PR TITLE
Explicitly set the attrs field of the Style struct to be an int64

### DIFF
--- a/get.go
+++ b/get.go
@@ -423,7 +423,7 @@ func (s Style) getAsBool(k propKey, defaultVal bool) bool {
 	if !s.isSet(k) {
 		return defaultVal
 	}
-	return s.attrs&int(k) != 0
+	return s.attrs&int64(k) != 0
 }
 
 func (s Style) getAsColor(k propKey) TerminalColor {

--- a/set.go
+++ b/set.go
@@ -68,16 +68,16 @@ func (s *Style) set(key propKey, value interface{}) {
 	default:
 		if v, ok := value.(bool); ok { //nolint:nestif
 			if v {
-				s.attrs |= int(key)
+				s.attrs |= int64(key)
 			} else {
-				s.attrs &^= int(key)
+				s.attrs &^= int64(key)
 			}
-		} else if attrs, ok := value.(int); ok {
+		} else if attrs, ok := value.(int64); ok {
 			// bool attrs
-			if attrs&int(key) != 0 {
-				s.attrs |= int(key)
+			if attrs&int64(key) != 0 {
+				s.attrs |= int64(key)
 			} else {
-				s.attrs &^= int(key)
+				s.attrs &^= int64(key)
 			}
 		}
 	}

--- a/style.go
+++ b/style.go
@@ -119,7 +119,7 @@ type Style struct {
 	value string
 
 	// we store bool props values here
-	attrs int
+	attrs int64
 
 	// props that have values
 	fgColor TerminalColor


### PR DESCRIPTION
This fixes test failures on 32bit systems where an int is only 32 bits long. (For example, see the Debian [build log](https://ci.debian.net/packages/g/golang-github-charmbracelet-lipgloss/testing/i386/50705933/) for i386.)