### PR TITLE
fix(table): use table height

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -532,14 +532,9 @@ func (t *Table) constructRow(index int, isOverflow bool) string {
 	for c := 0; c < t.data.Columns(); c++ {
 		cellWidth := t.widths[c]
 
-		// TODO(fix): small cells should be using '…' instead of '...'. This is rendered wrong when
-		// 	then cellWidth is greater than 3 but the visible cell (ie. after styling) is smaller than 3.
-		cell := "..."
-		switch {
-		case !isOverflow:
+		cell := "…"
+		if !isOverflow {
 			cell = t.data.At(index, c)
-		case cellWidth < 3:
-			cell = "…"
 		}
 
 		cells = append(cells, t.style(index+1, c).

--- a/table/table.go
+++ b/table/table.go
@@ -359,20 +359,20 @@ func (t *Table) String() string {
 
 	// If there are no data rows render nothing.
 	if t.data.Rows() > 0 {
-		topHeight := lipgloss.Height(sb.String()) - 1 // Subtract 1 for the newline.
+		// The height of the top border. Subtract 1 for the newline.
+		topHeight := lipgloss.Height(sb.String()) - 1
+
 		availableHeight := t.height - (topHeight + lipgloss.Height(bottom))
 		rowsToRender := min(availableHeight, t.data.Rows())
 
-		// The following replicates a do-while loop. When there is data we always render at least one row.
-		// Whenever the height is too small to render all rows, the bottom row will be an overflow row (ellipsis).
-		rowIdx := t.offset
-		for ok := true; ok; ok = rowIdx < rowsToRender {
-			isOverflow := rowsToRender == 0 ||
-				(rowIdx == rowsToRender-1 && rowsToRender < t.data.Rows())
+		// When there is data we always render at least one row.
+		rowsToRender = max(rowsToRender, 1)
+
+		for rowIdx := t.offset; rowIdx < rowsToRender; rowIdx++ {
+			// Whenever the height is too small to render all rows, the bottom row will be an overflow row (ellipsis).
+			isOverflow := rowsToRender < t.data.Rows()-1 && rowIdx == rowsToRender-1
 
 			sb.WriteString(t.constructRow(rowIdx, isOverflow))
-
-			rowIdx++
 		}
 	}
 

--- a/table/table.go
+++ b/table/table.go
@@ -53,9 +53,10 @@ type Table struct {
 	headers     []string
 	data        Data
 
-	width  int
-	height int
-	offset int
+	width           int
+	height          int
+	useManualHeight bool
+	offset          int
 
 	// widths tracks the width of each column.
 	widths []int
@@ -199,6 +200,7 @@ func (t *Table) Width(w int) *Table {
 // Height sets the table height.
 func (t *Table) Height(h int) *Table {
 	t.height = h
+	t.useManualHeight = true
 	return t
 }
 
@@ -359,11 +361,19 @@ func (t *Table) String() string {
 
 	// If there are no data rows render nothing.
 	if t.data.Rows() > 0 {
-		// The height of the top border. Subtract 1 for the newline.
-		topHeight := lipgloss.Height(sb.String()) - 1
-		availableLines := t.height - (topHeight + lipgloss.Height(bottom))
+		switch {
+		case t.useManualHeight:
+			// The height of the top border. Subtract 1 for the newline.
+			topHeight := lipgloss.Height(sb.String()) - 1
+			availableLines := t.height - (topHeight + lipgloss.Height(bottom))
 
-		sb.WriteString(t.constructRows(availableLines))
+			sb.WriteString(t.constructRows(availableLines))
+
+		default:
+			for r := t.offset; r < t.data.Rows(); r++ {
+				sb.WriteString(t.constructRow(r, false))
+			}
+		}
 	}
 
 	sb.WriteString(bottom)

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -22,6 +22,7 @@ var TableStyle = func(row, col int) lipgloss.Style {
 
 func TestTable(t *testing.T) {
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -61,6 +62,7 @@ func TestTableExample(t *testing.T) {
 	}
 
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("99"))).
 		StyleFunc(func(row, col int) lipgloss.Style {
@@ -98,6 +100,7 @@ func TestTableExample(t *testing.T) {
 
 func TestTableEmpty(t *testing.T) {
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL")
@@ -116,6 +119,7 @@ func TestTableEmpty(t *testing.T) {
 
 func TestTableOffset(t *testing.T) {
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -152,6 +156,7 @@ func TestTableBorder(t *testing.T) {
 	}
 
 	table := New().
+		Height(10).
 		Border(lipgloss.DoubleBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -183,6 +188,7 @@ func TestTableSetRows(t *testing.T) {
 		{"Spanish", "Hola", "¿Qué tal?"},
 	}
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -214,6 +220,7 @@ func TestMoreCellsThanHeaders(t *testing.T) {
 		{"Spanish", "Hola", "¿Qué tal?"},
 	}
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL").
@@ -246,6 +253,7 @@ func TestMoreCellsThanHeadersExtra(t *testing.T) {
 	}
 
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL").
@@ -270,6 +278,7 @@ func TestMoreCellsThanHeadersExtra(t *testing.T) {
 
 func TestTableNoHeaders(t *testing.T) {
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Row("Chinese", "Nǐn hǎo", "Nǐ hǎo").
@@ -295,6 +304,7 @@ func TestTableNoHeaders(t *testing.T) {
 
 func TestTableNoColumnSeparators(t *testing.T) {
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		BorderColumn(false).
 		StyleFunc(TableStyle).
@@ -321,6 +331,7 @@ func TestTableNoColumnSeparators(t *testing.T) {
 
 func TestTableNoColumnSeparatorsWithHeaders(t *testing.T) {
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		BorderColumn(false).
 		StyleFunc(TableStyle).
@@ -358,6 +369,7 @@ func TestBorderColumnsWithExtraRows(t *testing.T) {
 	}
 
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		BorderColumn(false).
 		StyleFunc(TableStyle).
@@ -399,6 +411,7 @@ func TestTableUnsetBorders(t *testing.T) {
 	}
 
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -432,6 +445,7 @@ func TestTableUnsetHeaderSeparator(t *testing.T) {
 	}
 
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -465,6 +479,7 @@ func TestTableUnsetHeaderSeparatorWithBorder(t *testing.T) {
 	}
 
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -497,6 +512,7 @@ func TestTableRowSeparators(t *testing.T) {
 	}
 
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		BorderRow(true).
@@ -542,6 +558,7 @@ func TestTableHeights(t *testing.T) {
 	}
 
 	table := New().
+		Height(100).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(styleFunc).
 		Headers("EXPRESSION", "MEANING").
@@ -594,6 +611,7 @@ func TestTableMultiLineRowSeparator(t *testing.T) {
 	}
 
 	table := New().
+		Height(100).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(styleFunc).
 		Headers("EXPRESSION", "MEANING").
@@ -650,6 +668,7 @@ func TestTableWidthExpand(t *testing.T) {
 
 	table := New().
 		Width(80).
+		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -687,6 +706,7 @@ func TestTableWidthShrink(t *testing.T) {
 
 	table := New().
 		Width(30).
+		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -718,6 +738,7 @@ func TestTableWidthSmartCrop(t *testing.T) {
 
 	table := New().
 		Width(25).
+		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("Name", "Age of Person", "Location").
@@ -750,6 +771,7 @@ func TestTableWidthSmartCropExtensive(t *testing.T) {
 
 	table := New().
 		Width(18).
+		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.ThickBorder()).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -784,6 +806,7 @@ func TestTableWidthSmartCropTiny(t *testing.T) {
 
 	table := New().
 		Width(1).
+		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -817,6 +840,7 @@ func TestTableWidths(t *testing.T) {
 
 	table := New().
 		Width(30).
+		Height(10).
 		StyleFunc(TableStyle).
 		BorderLeft(false).
 		BorderRight(false).
@@ -853,6 +877,7 @@ func TestTableWidthShrinkNoBorders(t *testing.T) {
 
 	table := New().
 		Width(30).
+		Height(10).
 		StyleFunc(TableStyle).
 		BorderLeft(false).
 		BorderRight(false).
@@ -891,6 +916,7 @@ func TestFilter(t *testing.T) {
 	})
 
 	table := New().
+		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -955,6 +981,7 @@ func TestTableANSI(t *testing.T) {
 
 	table := New().
 		Width(29).
+		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("Fruit", "Color", code).

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1063,7 +1063,7 @@ func TestTableHeightExtra(t *testing.T) {
 
 func TestTableHeightShrink(t *testing.T) {
 	table := New().
-		Height(6).
+		Height(8).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -1078,6 +1078,8 @@ func TestTableHeightShrink(t *testing.T) {
 │ LANGUAGE │    FORMAL    │ INFORMAL  │
 ├──────────┼──────────────┼───────────┤
 │ Chinese  │ Nǐn hǎo      │ Nǐ hǎo    │
+│ French   │ Bonjour      │ Salut     │
+│ Japanese │ こんにちは   │ やあ      │
 │ ...      │ ...          │ ...       │
 └──────────┴──────────────┴───────────┘
 `)
@@ -1092,18 +1094,50 @@ func TestTableHeightMinimum(t *testing.T) {
 		Height(0).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
+		Headers("ID", "LANGUAGE", "FORMAL", "INFORMAL").
+		Row("1", "Chinese", "Nǐn hǎo", "Nǐ hǎo").
+		Row("2", "French", "Bonjour", "Salut").
+		Row("3", "Japanese", "こんにちは", "やあ").
+		Row("4", "Russian", "Zdravstvuyte", "Privet").
+		Row("5", "Spanish", "Hola", "¿Qué tal?")
+
+	// TODO: the ID column should be using '…' instead of '...'. How to check cell width while accounting for padding?
+	expected := strings.TrimSpace(`
+┌────┬──────────┬──────────────┬───────────┐
+│ ID │ LANGUAGE │    FORMAL    │ INFORMAL  │
+├────┼──────────┼──────────────┼───────────┤
+│ .. │ ...      │ ...          │ ...       │
+└────┴──────────┴──────────────┴───────────┘
+`)
+
+	if table.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, table.String())
+	}
+}
+
+func TestTableHeightWithOffset(t *testing.T) {
+	//This test exists to check for a bug / edge case when the table has an offset and the height is exact.
+
+	table := New().
+		Height(8).
+		Border(lipgloss.NormalBorder()).
+		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
 		Row("Chinese", "Nǐn hǎo", "Nǐ hǎo").
 		Row("French", "Bonjour", "Salut").
 		Row("Japanese", "こんにちは", "やあ").
 		Row("Russian", "Zdravstvuyte", "Privet").
-		Row("Spanish", "Hola", "¿Qué tal?")
+		Row("Spanish", "Hola", "¿Qué tal?").
+		Offset(1)
 
 	expected := strings.TrimSpace(`
 ┌──────────┬──────────────┬───────────┐
 │ LANGUAGE │    FORMAL    │ INFORMAL  │
 ├──────────┼──────────────┼───────────┤
-│ ...      │ ...          │ ...       │
+│ French   │ Bonjour      │ Salut     │
+│ Japanese │ こんにちは   │ やあ      │
+│ Russian  │ Zdravstvuyte │ Privet    │
+│ Spanish  │ Hola         │ ¿Qué tal? │
 └──────────┴──────────────┴───────────┘
 `)
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1003,6 +1003,115 @@ func TestTableANSI(t *testing.T) {
 	}
 }
 
+func TestTableHeightExact(t *testing.T) {
+	table := New().
+		Height(9).
+		Border(lipgloss.NormalBorder()).
+		StyleFunc(TableStyle).
+		Headers("LANGUAGE", "FORMAL", "INFORMAL").
+		Row("Chinese", "Nǐn hǎo", "Nǐ hǎo").
+		Row("French", "Bonjour", "Salut").
+		Row("Japanese", "こんにちは", "やあ").
+		Row("Russian", "Zdravstvuyte", "Privet").
+		Row("Spanish", "Hola", "¿Qué tal?")
+
+	expected := strings.TrimSpace(`
+┌──────────┬──────────────┬───────────┐
+│ LANGUAGE │    FORMAL    │ INFORMAL  │
+├──────────┼──────────────┼───────────┤
+│ Chinese  │ Nǐn hǎo      │ Nǐ hǎo    │
+│ French   │ Bonjour      │ Salut     │
+│ Japanese │ こんにちは   │ やあ      │
+│ Russian  │ Zdravstvuyte │ Privet    │
+│ Spanish  │ Hola         │ ¿Qué tal? │
+└──────────┴──────────────┴───────────┘
+`)
+
+	if table.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, table.String())
+	}
+}
+
+func TestTableHeightExtra(t *testing.T) {
+	table := New().
+		Height(100).
+		Border(lipgloss.NormalBorder()).
+		StyleFunc(TableStyle).
+		Headers("LANGUAGE", "FORMAL", "INFORMAL").
+		Row("Chinese", "Nǐn hǎo", "Nǐ hǎo").
+		Row("French", "Bonjour", "Salut").
+		Row("Japanese", "こんにちは", "やあ").
+		Row("Russian", "Zdravstvuyte", "Privet").
+		Row("Spanish", "Hola", "¿Qué tal?")
+
+	expected := strings.TrimSpace(`
+┌──────────┬──────────────┬───────────┐
+│ LANGUAGE │    FORMAL    │ INFORMAL  │
+├──────────┼──────────────┼───────────┤
+│ Chinese  │ Nǐn hǎo      │ Nǐ hǎo    │
+│ French   │ Bonjour      │ Salut     │
+│ Japanese │ こんにちは   │ やあ      │
+│ Russian  │ Zdravstvuyte │ Privet    │
+│ Spanish  │ Hola         │ ¿Qué tal? │
+└──────────┴──────────────┴───────────┘
+`)
+
+	if table.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, table.String())
+	}
+}
+
+func TestTableHeightShrink(t *testing.T) {
+	table := New().
+		Height(6).
+		Border(lipgloss.NormalBorder()).
+		StyleFunc(TableStyle).
+		Headers("LANGUAGE", "FORMAL", "INFORMAL").
+		Row("Chinese", "Nǐn hǎo", "Nǐ hǎo").
+		Row("French", "Bonjour", "Salut").
+		Row("Japanese", "こんにちは", "やあ").
+		Row("Russian", "Zdravstvuyte", "Privet").
+		Row("Spanish", "Hola", "¿Qué tal?")
+
+	expected := strings.TrimSpace(`
+┌──────────┬──────────────┬───────────┐
+│ LANGUAGE │    FORMAL    │ INFORMAL  │
+├──────────┼──────────────┼───────────┤
+│ Chinese  │ Nǐn hǎo      │ Nǐ hǎo    │
+│ ...      │ ...          │ ...       │
+└──────────┴──────────────┴───────────┘
+`)
+
+	if table.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, table.String())
+	}
+}
+
+func TestTableHeightMinimum(t *testing.T) {
+	table := New().
+		Height(0).
+		Border(lipgloss.NormalBorder()).
+		StyleFunc(TableStyle).
+		Headers("LANGUAGE", "FORMAL", "INFORMAL").
+		Row("Chinese", "Nǐn hǎo", "Nǐ hǎo").
+		Row("French", "Bonjour", "Salut").
+		Row("Japanese", "こんにちは", "やあ").
+		Row("Russian", "Zdravstvuyte", "Privet").
+		Row("Spanish", "Hola", "¿Qué tal?")
+
+	expected := strings.TrimSpace(`
+┌──────────┬──────────────┬───────────┐
+│ LANGUAGE │    FORMAL    │ INFORMAL  │
+├──────────┼──────────────┼───────────┤
+│ ...      │ ...          │ ...       │
+└──────────┴──────────────┴───────────┘
+`)
+
+	if table.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, table.String())
+	}
+}
+
 func debug(s string) string {
 	return strings.ReplaceAll(s, " ", ".")
 }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -22,7 +22,6 @@ var TableStyle = func(row, col int) lipgloss.Style {
 
 func TestTable(t *testing.T) {
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -62,7 +61,6 @@ func TestTableExample(t *testing.T) {
 	}
 
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("99"))).
 		StyleFunc(func(row, col int) lipgloss.Style {
@@ -100,7 +98,6 @@ func TestTableExample(t *testing.T) {
 
 func TestTableEmpty(t *testing.T) {
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL")
@@ -119,7 +116,6 @@ func TestTableEmpty(t *testing.T) {
 
 func TestTableOffset(t *testing.T) {
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -156,7 +152,6 @@ func TestTableBorder(t *testing.T) {
 	}
 
 	table := New().
-		Height(10).
 		Border(lipgloss.DoubleBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -188,7 +183,6 @@ func TestTableSetRows(t *testing.T) {
 		{"Spanish", "Hola", "¿Qué tal?"},
 	}
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -220,7 +214,6 @@ func TestMoreCellsThanHeaders(t *testing.T) {
 		{"Spanish", "Hola", "¿Qué tal?"},
 	}
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL").
@@ -253,7 +246,6 @@ func TestMoreCellsThanHeadersExtra(t *testing.T) {
 	}
 
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL").
@@ -278,7 +270,6 @@ func TestMoreCellsThanHeadersExtra(t *testing.T) {
 
 func TestTableNoHeaders(t *testing.T) {
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Row("Chinese", "Nǐn hǎo", "Nǐ hǎo").
@@ -304,7 +295,6 @@ func TestTableNoHeaders(t *testing.T) {
 
 func TestTableNoColumnSeparators(t *testing.T) {
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		BorderColumn(false).
 		StyleFunc(TableStyle).
@@ -331,7 +321,6 @@ func TestTableNoColumnSeparators(t *testing.T) {
 
 func TestTableNoColumnSeparatorsWithHeaders(t *testing.T) {
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		BorderColumn(false).
 		StyleFunc(TableStyle).
@@ -369,7 +358,6 @@ func TestBorderColumnsWithExtraRows(t *testing.T) {
 	}
 
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		BorderColumn(false).
 		StyleFunc(TableStyle).
@@ -411,7 +399,6 @@ func TestTableUnsetBorders(t *testing.T) {
 	}
 
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -445,7 +432,6 @@ func TestTableUnsetHeaderSeparator(t *testing.T) {
 	}
 
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -479,7 +465,6 @@ func TestTableUnsetHeaderSeparatorWithBorder(t *testing.T) {
 	}
 
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -512,7 +497,6 @@ func TestTableRowSeparators(t *testing.T) {
 	}
 
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		BorderRow(true).
@@ -558,7 +542,6 @@ func TestTableHeights(t *testing.T) {
 	}
 
 	table := New().
-		Height(100).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(styleFunc).
 		Headers("EXPRESSION", "MEANING").
@@ -611,7 +594,6 @@ func TestTableMultiLineRowSeparator(t *testing.T) {
 	}
 
 	table := New().
-		Height(100).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(styleFunc).
 		Headers("EXPRESSION", "MEANING").
@@ -668,7 +650,6 @@ func TestTableWidthExpand(t *testing.T) {
 
 	table := New().
 		Width(80).
-		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -706,7 +687,6 @@ func TestTableWidthShrink(t *testing.T) {
 
 	table := New().
 		Width(30).
-		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -738,7 +718,6 @@ func TestTableWidthSmartCrop(t *testing.T) {
 
 	table := New().
 		Width(25).
-		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("Name", "Age of Person", "Location").
@@ -771,7 +750,6 @@ func TestTableWidthSmartCropExtensive(t *testing.T) {
 
 	table := New().
 		Width(18).
-		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.ThickBorder()).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -806,7 +784,6 @@ func TestTableWidthSmartCropTiny(t *testing.T) {
 
 	table := New().
 		Width(1).
-		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -840,7 +817,6 @@ func TestTableWidths(t *testing.T) {
 
 	table := New().
 		Width(30).
-		Height(10).
 		StyleFunc(TableStyle).
 		BorderLeft(false).
 		BorderRight(false).
@@ -877,7 +853,6 @@ func TestTableWidthShrinkNoBorders(t *testing.T) {
 
 	table := New().
 		Width(30).
-		Height(10).
 		StyleFunc(TableStyle).
 		BorderLeft(false).
 		BorderRight(false).
@@ -916,7 +891,6 @@ func TestFilter(t *testing.T) {
 	})
 
 	table := New().
-		Height(10).
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(TableStyle).
 		Headers("LANGUAGE", "FORMAL", "INFORMAL").
@@ -981,7 +955,6 @@ func TestTableANSI(t *testing.T) {
 
 	table := New().
 		Width(29).
-		Height(10).
 		StyleFunc(TableStyle).
 		Border(lipgloss.NormalBorder()).
 		Headers("Fruit", "Color", code).

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1053,7 +1053,7 @@ func TestTableHeightShrink(t *testing.T) {
 │ Chinese  │ Nǐn hǎo      │ Nǐ hǎo    │
 │ French   │ Bonjour      │ Salut     │
 │ Japanese │ こんにちは   │ やあ      │
-│ ...      │ ...          │ ...       │
+│ …        │ …            │ …         │
 └──────────┴──────────────┴───────────┘
 `)
 
@@ -1074,12 +1074,11 @@ func TestTableHeightMinimum(t *testing.T) {
 		Row("4", "Russian", "Zdravstvuyte", "Privet").
 		Row("5", "Spanish", "Hola", "¿Qué tal?")
 
-	// TODO: the ID column should be using '…' instead of '...'. How to check cell width while accounting for padding?
 	expected := strings.TrimSpace(`
 ┌────┬──────────┬──────────────┬───────────┐
 │ ID │ LANGUAGE │    FORMAL    │ INFORMAL  │
 ├────┼──────────┼──────────────┼───────────┤
-│ .. │ ...      │ ...          │ ...       │
+│ …  │ …        │ …            │ …         │
 └────┴──────────┴──────────────┴───────────┘
 `)
 
@@ -1110,7 +1109,8 @@ func TestTableHeightMinimumShowData(t *testing.T) {
 }
 
 func TestTableHeightWithOffset(t *testing.T) {
-	//This test exists to check for a bug / edge case when the table has an offset and the height is exact.
+	// This test exists to check for a bug/edge case when the table has an
+	// offset and the height is set.
 
 	table := New().
 		Height(8).

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1115,6 +1115,27 @@ func TestTableHeightMinimum(t *testing.T) {
 	}
 }
 
+func TestTableHeightMinimumShowData(t *testing.T) {
+	table := New().
+		Height(0).
+		Border(lipgloss.NormalBorder()).
+		StyleFunc(TableStyle).
+		Headers("LANGUAGE", "FORMAL", "INFORMAL").
+		Row("Chinese", "Nǐn hǎo", "Nǐ hǎo")
+
+	expected := strings.TrimSpace(`
+┌──────────┬─────────┬──────────┐
+│ LANGUAGE │ FORMAL  │ INFORMAL │
+├──────────┼─────────┼──────────┤
+│ Chinese  │ Nǐn hǎo │ Nǐ hǎo   │
+└──────────┴─────────┴──────────┘
+`)
+
+	if table.String() != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, table.String())
+	}
+}
+
 func TestTableHeightWithOffset(t *testing.T) {
 	//This test exists to check for a bug / edge case when the table has an offset and the height is exact.
 

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -491,7 +491,6 @@ func TestTreeTable(t *testing.T) {
 					"Baz",
 					table.New().
 						Width(20).
-						Height(10).
 						StyleFunc(func(row, col int) lipgloss.Style {
 							return lipgloss.NewStyle().Padding(0, 1)
 						}).

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -491,6 +491,7 @@ func TestTreeTable(t *testing.T) {
 					"Baz",
 					table.New().
 						Width(20).
+						Height(10).
 						StyleFunc(func(row, col int) lipgloss.Style {
 							return lipgloss.NewStyle().Padding(0, 1)
 						}).


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/lipgloss/issues/356

## Changes
* `table/table.go`: Modified the `constructRow` method to accept an `isOverflow` parameter, allowing rows to be rendered as overflow rows with ellipsis when necessary.
* `table/table.go`: Updated the `String` method to calculate the available height for rendering rows and handle the rendering of overflow rows correctly. Most of this lives in the new `constructRows` method.
* `table/table_test.go`: Added unit tests for the `Height` method.
* `table/table.go`: Added a boolean `useManualHeight` to the `Table` struct. I thought it would be good to maintain the existing functionality (auto table height) by default. I've put this in one commit so it can be easily removed if needed. The `useManualHeight` boolean tracks whether the user has manually set the height of the table. When `false`, the new height functionality will not be used. It is `false` by default and only set to `true` when the height is set (`table.Height(x)`).
  * Without this the existing table unit tests (and likely other users' code) would would have to change every `New` call to have a corresponding `Height` call. With this feature, height is flexible and calculated for you by default.
  * We could replace this bool with an understanding that `height == -1` represents auto height. Not sure what is preferred.

### How Height is Used

The default behaviour is the same as before, now there's just a few more features:
- Calling `New` without calling `Height` will render the full table (despite the `Table.height` value being 0). Example: the following table _technically_ has a height of 0, but the user did not set that so we assume they want to show the whole table:
```
╭──┬───────────────┬───────────────────╮
│ID│title          │description        │
├──┼───────────────┼───────────────────┤
│1 │Lost in Time   │A thrilling advent…│
│2 │Whispering Sha…│Secrets unravel in…│
│3 │Stolen Identity│An innocent man's …│
│4 │Into the Abyss │Exposing deep-root…│
╰──┴───────────────┴───────────────────╯
```
_NOTE: When the following examples say "set a height" they mean make a call to the `table.Height` method_
- If you set a height larger than the tables total height, it won't look any different. No extra lines are added. This is the same if you choose the exact height needed. Example, we could set the table height to 8 or 800 and we would still get this:
```
╭──┬───────────────┬───────────────────╮
│ID│title          │description        │
├──┼───────────────┼───────────────────┤
│1 │Lost in Time   │A thrilling advent…│
│2 │Whispering Sha…│Secrets unravel in…│
│3 │Stolen Identity│An innocent man's …│
│4 │Into the Abyss │Exposing deep-root…│
╰──┴───────────────┴───────────────────╯
```
- If you set a height so small that no rows can be rendered, and overflow row will still be rendered. Example, we could set the table height to 5 or anything less (including negatives) and we would get:
```
╭──┬───────────────┬───────────────────╮
│ID│title          │description        │
├──┼───────────────┼───────────────────┤
│… │...            │...                │
╰──┴───────────────┴───────────────────╯
```
- And finally, if you set a height between the last two examples (ie. enough to show a row but not enough to show all rows) then we render as many as possible finishing with an overflow row. Example, the following table has a height of 6:
```
╭──┬───────────────┬───────────────────╮
│ID│title          │description        │
├──┼───────────────┼───────────────────┤
│1 │Lost in Time   │A thrilling advent…│
│… │...            │...                │
╰──┴───────────────┴───────────────────╯
```

## Notes
- The height of a table is defined as the number of lines (ie. vertical cells) that the table takes up. This includes headers, data rows, and any styling.
- Since at least one data row is **always** displayed (even if it is just an overflow row), if the user sets the height to anything less than 5 but there is only one row of data to show, the data row will be shown instead of an overflow row. This stems from an assumption that if we are going to "force print" 5 lines (aka. 5 vertical cells) of text and there is only one data row anyway, we might as well show the user some useful information rather than an empty or overflow row.
- If the only row printed is an overflow row, the column widths are calculated for the original data and yet we are only printing ellipsis. Let me know if this is something that needs to be altered.

