### PR TITLE
fix(table): unset data rows without causing nil pointer err

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -85,7 +85,7 @@ func New() *Table {
 
 // ClearRows clears the table rows.
 func (t *Table) ClearRows() *Table {
-	t.data = nil
+	t.data = NewStringData()
 	return t
 }
 


### PR DESCRIPTION
Without this change `data` is set to `nil` causing nil ptr errors whenever we want to add data to the table after calling `ClearRow`. Instead, this function should reset the values without clearing the data type so it's still usable
