### PR TITLE
marking which border side is set when creating new border style

### DIFF
--- a/set.go
+++ b/set.go
@@ -445,6 +445,20 @@ func (s Style) Border(b Border, sides ...bool) Style {
 //	lipgloss.NewStyle().BorderStyle(lipgloss.ThickBorder())
 func (s Style) BorderStyle(b Border) Style {
 	s.set(borderStyleKey, b)
+
+	if isTopSet := b.Top; isTopSet != "" {
+		s.set(borderTopKey, true)
+	}
+	if isBottomSet := b.Bottom; isBottomSet != "" {
+		s.set(borderBottomKey, true)
+	}
+	if isLeftSet := b.Left; isLeftSet != "" {
+		s.set(borderLeftKey, true)
+	}
+	if isRightSet := b.Right; isRightSet != "" {
+		s.set(borderRightKey, true)
+	}
+
 	return s
 }
 

--- a/style_test.go
+++ b/style_test.go
@@ -576,3 +576,13 @@ func requireNotEqual(tb testing.TB, a, b interface{}) {
 		tb.FailNow()
 	}
 }
+
+func TestIsSet(t *testing.T) {
+	leftOnly := NewStyle().
+		BorderStyle(Border{Left: "   new             "}).
+		BorderForeground(Color("#FFA500"))
+	got := leftOnly.isSet(borderLeftKey)
+	if got != true {
+		t.Fatalf("expected the left border to be set, got: %#v, but the left border is: %#v", got, leftOnly.borderStyle.Left)
+	}
+}


### PR DESCRIPTION
Fixes  #366 

Enhance borderStyle function to track explicitly set border sides

- Updated the `borderStyle` function to not only apply the provided `border` argument but also to track which specific sides (top, right, bottom, left) have been explicitly set.

