### PR TITLE
feat: Add border text functions for top and bottom borders.

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -380,15 +380,12 @@ func renderHorizontalEdge(left, middle, right string, width int) string {
 		middle = " "
 	}
 
-	leftWidth := ansi.StringWidth(left)
-	rightWidth := ansi.StringWidth(right)
-
 	runes := []rune(middle)
 	j := 0
 
 	out := strings.Builder{}
 	out.WriteString(left)
-	for i := leftWidth + rightWidth; i < width+rightWidth; {
+	for i := 0; i < width-1; {
 		out.WriteRune(runes[j])
 		j++
 		if j >= len(runes) {

--- a/borders_test.go
+++ b/borders_test.go
@@ -1,0 +1,140 @@
+package lipgloss
+
+import "testing"
+
+func TestBorderFunc(t *testing.T) {
+
+	tt := []struct {
+		name     string
+		text     string
+		style    Style
+		expected string
+	}{
+		{
+			name: "top left title",
+			text: "",
+			style: NewStyle().Width(10).Border(NormalBorder()).BorderTopFunc(Left, func(width int, middle string) string {
+				return "TITLE"
+			}),
+			expected: `┌TITLE─────┐
+│          │
+└──────────┘`,
+		},
+		{
+			name: "top center title",
+			text: "",
+			style: NewStyle().Width(10).Border(NormalBorder()).BorderTopFunc(Center, func(width int, middle string) string {
+				return "TITLE"
+			}),
+			expected: `┌──TITLE───┐
+│          │
+└──────────┘`,
+		},
+		{
+			name: "top center title even",
+			text: "",
+			style: NewStyle().Width(11).Border(NormalBorder()).BorderTopFunc(Center, func(width int, middle string) string {
+				return "TITLE"
+			}),
+			expected: `┌───TITLE───┐
+│           │
+└───────────┘`,
+		},
+		{
+			name: "top right title",
+			text: "",
+			style: NewStyle().Width(10).Border(NormalBorder()).BorderTopFunc(Right, func(width int, middle string) string {
+				return "TITLE"
+			}),
+			expected: `┌─────TITLE┐
+│          │
+└──────────┘`,
+		},
+		{
+			name: "bottom left title",
+			text: "",
+			style: NewStyle().Width(10).Border(NormalBorder()).BorderBottomFunc(Left, func(width int, middle string) string {
+				return "STATUS"
+			}),
+			expected: `┌──────────┐
+│          │
+└STATUS────┘`,
+		},
+		{
+			name: "bottom center title",
+			text: "",
+			style: NewStyle().Width(10).Border(NormalBorder()).BorderBottomFunc(Center, func(width int, middle string) string {
+				return "STATUS"
+			}),
+			expected: `┌──────────┐
+│          │
+└──STATUS──┘`,
+		},
+		{
+			name: "bottom center title odd",
+			text: "",
+			style: NewStyle().Width(11).Border(NormalBorder()).BorderBottomFunc(Center, func(width int, middle string) string {
+				return "STATUS"
+			}),
+			expected: `┌───────────┐
+│           │
+└──STATUS───┘`,
+		},
+		{
+			name: "bottom right title",
+			text: "",
+			style: NewStyle().Width(10).Border(NormalBorder()).BorderBottomFunc(Right, func(width int, middle string) string {
+				return "STATUS"
+			}),
+			expected: `┌──────────┐
+│          │
+└────STATUS┘`,
+		},
+	}
+
+	for i, tc := range tt {
+		res := tc.style.Render(tc.text)
+		if res != tc.expected {
+			t.Errorf("Test %d, expected:\n\n`%s`\n`%s`\n\nActual output:\n\n`%s`\n`%s`\n\n",
+				i, tc.expected, formatEscapes(tc.expected),
+				res, formatEscapes(res))
+		}
+	}
+
+}
+
+func TestBorders(t *testing.T) {
+	tt := []struct {
+		name     string
+		text     string
+		style    Style
+		expected string
+	}{
+		{
+			name:  "border with width",
+			text:  "",
+			style: NewStyle().Width(10).Border(NormalBorder()),
+			expected: `┌──────────┐
+│          │
+└──────────┘`,
+		},
+		{
+			name:  "top center title",
+			text:  "HELLO",
+			style: NewStyle().Border(NormalBorder()),
+			expected: `┌─────┐
+│HELLO│
+└─────┘`,
+		},
+	}
+
+	for i, tc := range tt {
+		res := tc.style.Render(tc.text)
+		if res != tc.expected {
+			t.Errorf("Test %d, expected:\n\n`%s`\n`%s`\n\nActual output:\n\n`%s`\n`%s`\n\n",
+				i, tc.expected, formatEscapes(tc.expected),
+				res, formatEscapes(res))
+		}
+	}
+
+}

--- a/set.go
+++ b/set.go
@@ -55,6 +55,10 @@ func (s *Style) set(key propKey, value interface{}) {
 		s.borderBottomBgColor = colorOrNil(value)
 	case borderLeftBackgroundKey:
 		s.borderLeftBgColor = colorOrNil(value)
+	case borderTopFuncKey:
+		s.borderTopFunc = mergeBorderFunc(s.borderTopFunc, value.([]BorderFunc))
+	case borderBottomFuncKey:
+		s.borderBottomFunc = mergeBorderFunc(s.borderBottomFunc, value.([]BorderFunc))
 	case maxWidthKey:
 		s.maxWidth = max(0, value.(int))
 	case maxHeightKey:
@@ -137,6 +141,12 @@ func (s *Style) setFrom(key propKey, i Style) {
 		s.set(borderBottomBackgroundKey, i.borderBottomBgColor)
 	case borderLeftBackgroundKey:
 		s.set(borderLeftBackgroundKey, i.borderLeftBgColor)
+	case borderTopFuncKey:
+		s.borderTopFunc = make([]BorderFunc, 3)
+		copy(s.borderTopFunc, i.borderTopFunc)
+	case borderBottomFuncKey:
+		s.borderBottomFunc = make([]BorderFunc, 3)
+		copy(s.borderBottomFunc, i.borderBottomFunc)
 	case maxWidthKey:
 		s.set(maxWidthKey, i.maxWidth)
 	case maxHeightKey:
@@ -156,6 +166,21 @@ func colorOrNil(c interface{}) TerminalColor {
 		return c
 	}
 	return nil
+}
+
+func mergeBorderFunc(a, b []BorderFunc) []BorderFunc {
+	if len(a) < 3 {
+		aa := make([]BorderFunc, 3)
+		copy(aa, a)
+		a = aa
+	}
+	for i := range b {
+		if b[i] != nil {
+			a[i] = b[i]
+			break
+		}
+	}
+	return a
 }
 
 // Bold sets a bold formatting rule.
@@ -588,6 +613,32 @@ func (s Style) BorderBottomBackground(c TerminalColor) Style {
 // border.
 func (s Style) BorderLeftBackground(c TerminalColor) Style {
 	s.set(borderLeftBackgroundKey, c)
+	return s
+}
+
+func posIndex(p Position) int {
+	switch p {
+	case Center:
+		return 1
+	case Right:
+		return 2
+	}
+	return 0
+}
+
+// BorderTopFunc set the top func
+func (s Style) BorderTopFunc(p Position, bf BorderFunc) Style {
+	fns := make([]BorderFunc, 3)
+	fns[posIndex(p)] = bf
+	s.set(borderTopFuncKey, fns)
+	return s
+}
+
+// BorderBottomFunc set the bottom func
+func (s Style) BorderBottomFunc(p Position, bf BorderFunc) Style {
+	fns := make([]BorderFunc, 3)
+	fns[posIndex(p)] = bf
+	s.set(borderBottomFuncKey, fns)
 	return s
 }
 

--- a/style.go
+++ b/style.go
@@ -69,6 +69,9 @@ const (
 	borderBottomBackgroundKey
 	borderLeftBackgroundKey
 
+	borderTopFuncKey
+	borderBottomFuncKey
+
 	inlineKey
 	maxWidthKey
 	maxHeightKey
@@ -151,6 +154,8 @@ type Style struct {
 	borderRightBgColor  TerminalColor
 	borderBottomBgColor TerminalColor
 	borderLeftBgColor   TerminalColor
+	borderTopFunc       []BorderFunc
+	borderBottomFunc    []BorderFunc
 
 	maxWidth  int
 	maxHeight int


### PR DESCRIPTION
This allows to set titles and status information in the borders.

This solves the issue where I keep trying to add some status information to the bottom of a border. I either need to take it apart and rebuild it with the additional information or create my own bottom border. This also allows setting some title information, which is nice too. 

this still need some error checking if someone returns longer strings. 

```go
type BorderFunc func(width int, middle string) string

func (s Style) BorderTopFunc(p Position, bf BorderFunc) Style 
func (s Style) BorderBottomFunc(p Position, bf BorderFunc) Style 
```

Example.. 
```go
    NewStyle().
        Width(10).
        Border(NormalBorder()).
        BorderTopFunc(Left, func(width int, middle string) string {
            return "TITLE" 
        })
```

```text
┌TITLE─────┐
│          │
└──────────┘
```

will allow to set functions for each corner 

```text
┌A───B───C┐
│         │
└D───E───F┘
```
