### PR TITLE
fix(render): strip carriage returns from strings

### DIFF
--- a/style.go
+++ b/style.go
@@ -353,6 +353,8 @@ func (s Style) Render(strs ...string) string {
 
 	// Potentially convert tabs to spaces
 	str = s.maybeConvertTabs(str)
+	// carriage returns can cause strange behaviour when rendering.
+	str = strings.ReplaceAll(str, "\r", "")
 
 	// Strip newlines in single line mode
 	if inline {

--- a/style.go
+++ b/style.go
@@ -354,7 +354,7 @@ func (s Style) Render(strs ...string) string {
 	// Potentially convert tabs to spaces
 	str = s.maybeConvertTabs(str)
 	// carriage returns can cause strange behaviour when rendering.
-	str = strings.ReplaceAll(str, "\r", "")
+	str = strings.ReplaceAll(str, "\r\n", "\n")
 
 	// Strip newlines in single line mode
 	if inline {

--- a/style_test.go
+++ b/style_test.go
@@ -1,6 +1,7 @@
 package lipgloss
 
 import (
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -574,5 +575,18 @@ func requireNotEqual(tb testing.TB, a, b interface{}) {
 	if reflect.DeepEqual(a, b) {
 		tb.Errorf("%v == %v", a, b)
 		tb.FailNow()
+	}
+}
+
+func TestCarriageReturnInRender(t *testing.T) {
+	out := fmt.Sprintf("%s\r\n%s\r\n", "Super duper california oranges", "Hello world")
+	testStyle := NewStyle().
+		MarginLeft(1)
+	got := testStyle.Render(string(out))
+	want := testStyle.Render(fmt.Sprintf("%s\n%s\n", "Super duper california oranges", "Hello world"))
+
+	if got != want {
+		t.Logf("got(detailed):\n%q\nwant(detailed):\n%q", got, want)
+		t.Fatalf("got(string):\n%s\nwant(string):\n%s", got, want)
 	}
 }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1158,6 +1158,34 @@ func TestClearRows(t *testing.T) {
 	table.String()
 }
 
+func TestCarriageReturn(t *testing.T) {
+	data := [][]string{
+		{"a0", "b0", "c0", "d0"},
+		{"a1", "b1.0\r\nb1.1\r\nb1.2\r\nb1.3\r\nb1.4\r\nb1.5\r\nb1.6", "c1", "d1"},
+		{"a2", "b2", "c2", "d2"},
+		{"a3", "b3", "c3", "d3"},
+	}
+	table := New().Rows(data...).Border(lipgloss.NormalBorder())
+	got := table.String()
+	want := `┌──┬────┬──┬──┐
+│a0│b0  │c0│d0│
+│a1│b1.0│c1│d1│
+│  │b1.1│  │  │
+│  │b1.2│  │  │
+│  │b1.3│  │  │
+│  │b1.4│  │  │
+│  │b1.5│  │  │
+│  │b1.6│  │  │
+│a2│b2  │c2│d2│
+│a3│b3  │c3│d3│
+└──┴────┴──┴──┘`
+
+	if got != want {
+		t.Logf("detailed view...\ngot:\n%q\nwant:\n%q", got, want)
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
 func debug(s string) string {
 	return strings.ReplaceAll(s, " ", ".")
 }


### PR DESCRIPTION
If a string contains carriage returns `\r`, it will cause some funky issues when rendering. More specifically any time we do any string concatenation, string A will be overwritten by string B instead of appended.

this is an example log output when a string has a `\r` and goes through `alignHorizontal` to pad spaces 
```
2024/10/07 13:36:43 end of horizontal align
git: 'defer' is not a git command. See 'git --help'.
----------------------------------------------------
-----------------------ds are
------------------------------------------
------------------------------------------
----------------------------------------------------
```

After this change:
```
2024/10/07 13:53:24 end of horizontal align
git: 'defer' is not a git command. See 'git --help'.
----------------------------------------------------
The most similar commands are-----------------------
    rerere------------------------------------------
    revert------------------------------------------
----------------------------------------------------
```

related:
https://github.com/charmbracelet/freeze/pull/119