### PR TITLE
fix(getLines): carriage return was not being removed with new lines.

### DIFF
--- a/get.go
+++ b/get.go
@@ -531,7 +531,11 @@ func (s Style) getAsTransform(propKey) func(string) string {
 func getLines(s string) (lines []string, widest int) {
 	lines = strings.Split(s, "\n")
 
-	for _, l := range lines {
+	for i, l := range lines {
+		// drop carriage return.
+		if len(l) > 0 && l[len(l)-1] == '\r' {
+			lines[i] = l[:len(l)-1]
+		}
 		w := ansi.StringWidth(l)
 		if widest < w {
 			widest = w

--- a/style_test.go
+++ b/style_test.go
@@ -473,6 +473,18 @@ func TestStyleValue(t *testing.T) {
 			style:    NewStyle().MarginLeft(1),
 			expected: " ",
 		},
+		{
+			name:     "width with carriage return",
+			text:     "foo\r\nbar",
+			style:    NewStyle().Width(10),
+			expected: "foo       \nbar       ",
+		},
+		{
+			name:     "center align with carriage return",
+			text:     "foo\r\nbar",
+			style:    NewStyle().Width(10).Align(Center),
+			expected: "   foo    \n   bar    ",
+		},
 	}
 
 	for i, tc := range tt {


### PR DESCRIPTION
getLines function is returning lines with out trimming the trailing carriage return.

anything using this might be appending strings to the carriage return terminated strings causing formatting issues.

Related 
#383 
#386