### PR TITLE
feat: simplify adaptive package and expose QueryBackgroundColor

### DIFF
--- a/adaptive/color.go
+++ b/adaptive/color.go
@@ -2,10 +2,12 @@ package adaptive
 
 import (
 	"image/color"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // Color returns the color that should be used based on the terminal's
 // background color.
 func Color(light, dark any) color.Color {
-	return colorFn.Color(light, dark)
+	return lipgloss.Adapt(HasDarkBackground).Color(light, dark)
 }


### PR DESCRIPTION
Remove unnecessary global variables and functions from the adaptive package. Instead of using a global variable to store the color function, the color function is now created on the fly when needed.