### PR TITLE
fix(examples): draw nested structure in file tree example

### DIFF
--- a/examples/debug.txt
+++ b/examples/debug.txt
@@ -1,4 +1,0 @@
-2024/05/09 16:27:51 Init Color profile: TrueColor
-2024/05/09 16:27:51 NoColor env: true
-2024/05/09 16:27:51 Color profile: Ascii
-2024/05/09 16:27:51 Has light background: false

--- a/examples/tree/files/main.go
+++ b/examples/tree/files/main.go
@@ -4,25 +4,69 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/tree"
 )
 
+func addBranches(root *tree.Tree, path string) error {
+	items, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range items {
+		if item.IsDir() {
+			// It's a directory.
+
+			// Skip directories that start with a dot.
+			if strings.HasPrefix(item.Name(), ".") {
+				continue
+			}
+
+			treeBranch := tree.Root(item.Name())
+			root.Child(treeBranch)
+
+			// Recurse.
+			branchPath := filepath.Join(path, item.Name())
+			if err := addBranches(treeBranch, branchPath); err != nil {
+				return err
+			}
+		} else {
+			// It's a file.
+
+			// Skip files that start with a dot.
+			if strings.HasPrefix(item.Name(), ".") {
+				continue
+			}
+
+			root.Child(item.Name())
+		}
+	}
+
+	return nil
+}
+
 func main() {
 	enumeratorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).PaddingRight(1)
 	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("99")).Bold(true).PaddingRight(1)
 
-	t := tree.Root(".").EnumeratorStyle(enumeratorStyle).ItemStyle(itemStyle)
-	_ = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			t.Child(tree.Root(path))
-		}
-		return nil
-	})
+	pwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting current working directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	t := tree.Root(pwd).
+		EnumeratorStyle(enumeratorStyle).
+		RootStyle(itemStyle).
+		ItemStyle(itemStyle)
+
+	if err := addBranches(t, "."); err != nil {
+		fmt.Fprintf(os.Stderr, "Error building tree: %v\n", err)
+		os.Exit(1)
+	}
 
 	fmt.Println(t)
 }


### PR DESCRIPTION
This updates the `tree/files` example to draw a nested file tree.

For example, here is its walking through the current `examples` directory in this repo:

```
/home/christian/lipgloss/examples
├── go.mod 
├── go.sum 
├── layout 
│   └── main.go 
├── list 
│   ├── duckduckgoose 
│   │   └── main.go 
│   ├── glow 
│   │   └── main.go 
│   ├── grocery 
│   │   └── main.go 
│   ├── roman 
│   │   └── main.go 
│   ├── simple 
│   │   └── main.go 
│   └── sublist 
│       └── main.go 
├── ssh 
│   └── main.go 
├── table 
│   ├── ansi 
│   │   └── main.go 
│   ├── chess 
│   │   └── main.go 
│   ├── demo.tape 
│   ├── languages 
│   │   └── main.go 
│   ├── mindy 
│   │   └── main.go 
│   └── pokemon 
│       └── main.go 
└── tree 
    ├── background 
    │   └── main.go 
    ├── files 
    │   └── main.go 
    ├── makeup 
    │   └── main.go 
    ├── rounded 
    │   └── main.go 
    ├── simple 
    │   └── main.go 
    ├── styles 
    │   └── main.go 
    └── toggle 
        └── main.go 
```