### PR TITLE
docs(list): fix list examples in godoc

### DIFF
--- a/list/enumerator.go
+++ b/list/enumerator.go
@@ -16,11 +16,11 @@ import (
 //	}
 //
 // There are several predefined enumerators:
-// • Alphabet
-// • Arabic
-// • Bullet
-// • Dash
-// • Roman
+//   - Alphabet
+//   - Arabic
+//   - Bullet
+//   - Dash
+//   - Roman
 //
 // Or, define your own.
 type Enumerator func(items Items, index int) string
@@ -43,10 +43,11 @@ type Indenter func(items Items, index int) string
 
 // Alphabet is the enumeration for alphabetical listing.
 //
-// a. Foo
-// b. Bar
-// c. Baz
-// d. Qux.
+//	Example:
+//	  a. Foo
+//	  b. Bar
+//	  c. Baz
+//	  d. Qux.
 func Alphabet(_ Items, i int) string {
 	if i >= abcLen*abcLen+abcLen {
 		return fmt.Sprintf("%c%c%c.", 'A'+i/abcLen/abcLen-1, 'A'+(i/abcLen)%abcLen-1, 'A'+i%abcLen)
@@ -61,16 +62,18 @@ const abcLen = 26
 
 // Arabic is the enumeration for arabic numerals listing.
 //
-// 1. Foo
-// 2. Bar
-// 3. Baz
-// 4. Qux.
+//	Example:
+//	  1. Foo
+//	  2. Bar
+//	  3. Baz
+//	  4. Qux.
 func Arabic(_ Items, i int) string {
 	return fmt.Sprintf("%d.", i+1)
 }
 
 // Roman is the enumeration for roman numerals listing.
 //
+//	Example:
 //	  I. Foo
 //	 II. Bar
 //	III. Baz
@@ -93,30 +96,33 @@ func Roman(_ Items, i int) string {
 
 // Bullet is the enumeration for bullet listing.
 //
-// • Foo
-// • Bar
-// • Baz
-// • Qux.
+//	Example:
+//	  • Foo
+//	  • Bar
+//	  • Baz
+//	  • Qux.
 func Bullet(Items, int) string {
 	return "•"
 }
 
 // Asterisk is an enumeration using asterisks.
 //
-// * Foo
-// * Bar
-// * Baz
-// * Qux.
+//	Example:
+//	  * Foo
+//	  * Bar
+//	  * Baz
+//	  * Qux.
 func Asterisk(Items, int) string {
 	return "*"
 }
 
 // Dash is an enumeration using dashes.
 //
-// - Foo
-// - Bar
-// - Baz
-// - Qux.
+//	Example:
+//	  - Foo
+//	  - Bar
+//	  - Baz
+//	  - Qux.
 func Dash(Items, int) string {
 	return "-"
 }


### PR DESCRIPTION
Closes #337 

Before:
![image](https://github.com/user-attachments/assets/e4b9584b-20bd-441e-ad66-83c4a8ddec12)

After:
![image](https://github.com/user-attachments/assets/29af80cf-96c0-429f-ad94-7e68d6306c3e)