### PR TITLE
docs: include warning about table offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,9 @@ fmt.Println(t)
 
 ![Table Example](https://github.com/charmbracelet/lipgloss/assets/42545625/6e4b70c4-f494-45da-a467-bdd27df30d5d)
 
+> [!WARNING]
+> Table `Rows` need to be declared before `Offset` otherwise it does nothing.
+
 For more on tables see [the docs](https://pkg.go.dev/github.com/charmbracelet/lipgloss?tab=doc) and [examples](https://github.com/charmbracelet/lipgloss/tree/master/examples/table).
 
 ## Rendering Lists

--- a/table/table.go
+++ b/table/table.go
@@ -209,6 +209,9 @@ func (t *Table) Height(h int) *Table {
 }
 
 // Offset sets the table rendering offset.
+//
+// Warning: you may declare Offset only after setting Rows. Otherwise it will be
+// ignored.
 func (t *Table) Offset(o int) *Table {
 	t.offset = o
 	return t


### PR DESCRIPTION
I'm not sure if we need to include this in the README or not, but added it just in case. Let me know :)
Closes #371
