### PR TITLE
refactor: unexport isDarkColor helper

### DIFF
--- a/color.go
+++ b/color.go
@@ -159,18 +159,18 @@ func LightDark(isDark bool) LightDarkFunc {
 	}
 }
 
-// IsDarkColor returns whether the given color is dark (based on the luminance
+// isDarkColor returns whether the given color is dark (based on the luminance
 // portion of the color as interpreted as HSL).
 //
 // Example usage:
 //
 //	color := lipgloss.Color("#0000ff")
-//	if lipgloss.IsDarkColor(color) {
+//	if lipgloss.isDarkColor(color) {
 //		fmt.Println("It's dark! I love darkness!")
 //	} else {
 //		fmt.Println("It's light! Cover your eyes!")
 //	}
-func IsDarkColor(c color.Color) bool {
+func isDarkColor(c color.Color) bool {
 	col, ok := colorful.MakeColor(c)
 	if !ok {
 		return true

--- a/query.go
+++ b/query.go
@@ -32,8 +32,7 @@ func BackgroundColor(in *os.File, out *os.File) (color.Color, error) {
 }
 
 // HasDarkBackground detects whether the terminal has a light or dark
-// background. It's a convenience function that wraps [BackgroundColor] and
-// [lipgloss.IsDarkColor].
+// background.
 //
 // Typically, you'll want to query against stdin and either stdout or stderr
 // depending on what you're writing to.
@@ -56,5 +55,5 @@ func HasDarkBackground(in *os.File, out *os.File) (bool, error) {
 		return true, errors.New("detected background color is nil")
 	}
 
-	return IsDarkColor(bg), nil
+	return isDarkColor(bg), nil
 }


### PR DESCRIPTION
make it less confusing for users - they shouldn't need to use this func