### PR TITLE
docs(examples): fix incorrect romanization of bulbasaur line

### DIFF
--- a/examples/table/pokemon/main.go
+++ b/examples/table/pokemon/main.go
@@ -39,9 +39,9 @@ func main() {
 
 	headers := []string{"#", "Name", "Type 1", "Type 2", "Japanese", "Official Rom."}
 	data := [][]string{
-		{"1", "Bulbasaur", "Grass", "Poison", "フシギダネ", "Bulbasaur"},
-		{"2", "Ivysaur", "Grass", "Poison", "フシギソウ", "Ivysaur"},
-		{"3", "Venusaur", "Grass", "Poison", "フシギバナ", "Venusaur"},
+		{"1", "Bulbasaur", "Grass", "Poison", "フシギダネ", "Fushigidane"},
+		{"2", "Ivysaur", "Grass", "Poison", "フシギソウ", "Fushigisou"},
+		{"3", "Venusaur", "Grass", "Poison", "フシギバナ", "Fushigibana"},
 		{"4", "Charmander", "Fire", "", "ヒトカゲ", "Hitokage"},
 		{"5", "Charmeleon", "Fire", "", "リザード", "Lizardo"},
 		{"6", "Charizard", "Fire", "Flying", "リザードン", "Lizardon"},


### PR DESCRIPTION
Likely an insignificant change, but I fixed the incorrect romaji for the Bulbasaur line.

Bulbasaur => [Fushigidane](https://bulbapedia.bulbagarden.net/wiki/Bulbasaur_(Pok%C3%A9mon)#:~:text=Bulbasaur%20(Japanese%3A%20%E3%83%95%E3%82%B7%E3%82%AE%E3%83%80%E3%83%8D-,fushigidane,-)%20is%20a%20dual)
Ivysaur => [Fushigisou](https://bulbapedia.bulbagarden.net/wiki/Bulbasaur_(Pok%C3%A9mon)#:~:text=Bulbasaur%20(Japanese%3A%20%E3%83%95%E3%82%B7%E3%82%AE%E3%83%80%E3%83%8D-,fushigidane,-)%20is%20a%20dual)
Venusaur => [Fushigibana](https://bulbapedia.bulbagarden.net/wiki/Venusaur_(Pok%C3%A9mon)#:~:text=Venusaur%20(Japanese%3A%20%E3%83%95%E3%82%B7%E3%82%AE%E3%83%90%E3%83%8A-,fushigibana,-)%20is%20a%20dual)

The Japanese text is written in [Katakana](https://en.wikipedia.org/wiki/Katakana), one of the three Japanese writing systems.