### PR TITLE
wip: Column wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.6.1-0.20250107110353-48b574af22a5
 	github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a
 	github.com/muesli/termenv v0.15.2
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/rivo/uniseg v0.4.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,13 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/table/table.go
+++ b/table/table.go
@@ -467,8 +467,9 @@ func (t *Table) constructHeaders() string {
 		s.WriteString(t.style(HeaderRow, i).
 			MaxHeight(1).
 			Width(t.widths[i]).
-			MaxWidth(t.widths[i]).
-			Render(ansi.Truncate(header, t.widths[i], "…")))
+			//			MaxWidth(t.widths[i]).
+			Render(header))
+		// Render(ansi.Truncate(header, t.widths[i], "…")))
 		if i < len(t.headers)-1 && t.borderColumn {
 			s.WriteString(t.borderStyle.Render(t.border.Left))
 		}

--- a/table/table.go
+++ b/table/table.go
@@ -308,13 +308,26 @@ func (t *Table) String() string {
 		// column, and shrink the columns based on the largest difference.
 		columnMedians := make([]int, len(t.widths))
 		for c := range t.widths {
-			trimmedWidth := make([]int, t.data.Rows())
+			trimmedWidth := make([]int, btoi(hasHeaders)+t.data.Rows())
+
+			// Get median widths across headers.
+			d := t.headers[c]
+			renderedCell := t.style(HeaderRow, c).Render(d)
+			nonWhitespaceChars := lipgloss.Width(strings.TrimRight(renderedCell, " "))
+			trimmedWidth[0] = nonWhitespaceChars + 1
+
+			columnMedians[c] = median(trimmedWidth)
+
+			// Get median widths across rows.
 			for r := 0; r < t.data.Rows(); r++ {
-				renderedCell := t.style(r+btoi(hasHeaders), c).Render(t.data.At(r, c))
+				d := t.data.At(r, c)
+				renderedCell := t.style(r, c).Render(d)
 				nonWhitespaceChars := lipgloss.Width(strings.TrimRight(renderedCell, " "))
-				trimmedWidth[r] = nonWhitespaceChars + 1
+				// Index 0 of trimmedWidth is the header row.
+				trimmedWidth[r+1] = nonWhitespaceChars + 1
 			}
 
+			// Get the median based on all header and row values in the current column.
 			columnMedians[c] = median(trimmedWidth)
 		}
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1215,6 +1215,16 @@ func TestClearRows(t *testing.T) {
 	table.String()
 }
 
+func TestContentWrapping(t *testing.T) {
+	table := New().
+		Headers("Name", "Description", "Type", "Required", "Default").
+		Row("command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes")
+	//		Row("command", lipgloss.NewStyle().Width(60).Render("A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures."), "yes")
+	table.Width(80)
+
+	t.Log("\n" + table.String() + "\n")
+}
+
 func TestCarriageReturn(t *testing.T) {
 	data := [][]string{
 		{"a0", "b0", "c0", "d0"},

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1216,13 +1216,40 @@ func TestClearRows(t *testing.T) {
 }
 
 func TestContentWrapping(t *testing.T) {
-	table := New().
-		Headers("Name", "Description", "Type", "Required", "Default").
-		Row("command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes")
-	//		Row("command", lipgloss.NewStyle().Width(60).Render("A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures."), "yes")
-	table.Width(80)
+	//	data := []string{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "hello", "yep"}
+	//
+	//	table := New().
+	//		Headers("Name", "Description", "Type", "Required", "Default").
+	//		Row(data...).
+	//		StyleFunc(func(_, col int) lipgloss.Style {
+	//			if len(data[col]) > 25 {
+	//				return lipgloss.NewStyle().Width(30)
+	//			}
+	//			return lipgloss.NewStyle()
+	//		})
+	//	//		Row("command", lipgloss.NewStyle().Width(60).Render("A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures."), "yes")
+	//	table.Width(80)
+	//
+	//	t.Log(lipgloss.Width(table.String()))
+	//	t.Log("\n" + table.String() + "\n")
 
-	t.Log("\n" + table.String() + "\n")
+	dataWithMissingValues := []string{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "", ""}
+
+	tableWithMissingValues := New().
+		Width(80).
+		Headers("Name", "Description", "Type", "Required", "Default").
+		Row(dataWithMissingValues...)
+	//		StyleFunc(func(_, col int) lipgloss.Style {
+	//			if len(dataWithMissingValues[col]) > 25 {
+	//				return lipgloss.NewStyle().Width(60)
+	//			}
+	//			return lipgloss.NewStyle()
+	//		})
+	//		Row("command", lipgloss.NewStyle().Width(60).Render("A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures."), "yes")
+	tableWithMissingValues.Width(80)
+
+	t.Log(lipgloss.Width(tableWithMissingValues.String()))
+	t.Log("\n" + tableWithMissingValues.String() + "\n")
 }
 
 func TestCarriageReturn(t *testing.T) {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"unicode"
@@ -9,6 +10,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/exp/golden"
 	"github.com/muesli/termenv"
+	"github.com/olekukonko/tablewriter"
 )
 
 var TableStyle = func(row, col int) lipgloss.Style {
@@ -1215,41 +1217,235 @@ func TestClearRows(t *testing.T) {
 	table.String()
 }
 
+// TODO add tests to check calculations for
+// - long text, small header
+// - long header, small text
+// - padding and wrapping
+
 func TestContentWrapping(t *testing.T) {
-	//	data := []string{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "hello", "yep"}
-	//
-	//	table := New().
-	//		Headers("Name", "Description", "Type", "Required", "Default").
-	//		Row(data...).
-	//		StyleFunc(func(_, col int) lipgloss.Style {
-	//			if len(data[col]) > 25 {
-	//				return lipgloss.NewStyle().Width(30)
-	//			}
-	//			return lipgloss.NewStyle()
-	//		})
-	//	//		Row("command", lipgloss.NewStyle().Width(60).Render("A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures."), "yes")
-	//	table.Width(80)
-	//
-	//	t.Log(lipgloss.Width(table.String()))
-	//	t.Log("\n" + table.String() + "\n")
+	tests := []struct {
+		name    string
+		headers []string
+		data    [][]string
+	}{
+		{
+			"long row content",
+			[]string{"Name", "Description", "Type", "Required", "Default"},
+			[][]string{{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "hello", "yep"}},
+		},
+		{
+			"missing row content",
+			[]string{"Name", "Description", "Type", "Required", "Default"},
+			[][]string{{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "", ""}},
+		},
+		{
+			"long header content, long and short rows",
+			[]string{"Destination", "Why are you going on this trip? Is it a hot or cold climate?", "Affordability"},
+			[][]string{
+				{"Mexico", "I want to go somewhere hot, dry, and affordable. Mexico has really good food, just don't drink tap water!", "$"},
+				{"New York", "I'm thinking about going during the Christmas season to check out Rockefeller center. Might be cold though...", "$$$"},
+				{"California", "", "$$$"},
+			},
+		},
+		{
+			"Long text, different languages",
+			[]string{"Hello", "你好", "مرحبًا", "안녕하세요"},
+			[][]string{
+				{
+					"Lorem ipsum dolor sit amet, regione detracto eos an. Has ei quidam hendrerit intellegebat, id tamquam iudicabit necessitatibus ius, at errem officiis hendrerit mei. Exerci noster at has, sit id tota convenire, vel ex rebum inciderint liberavisse. Quaeque delectus corrumpit cu cum.",
+					`耐許ヱヨカハ調出あゆ監件び理別よン國給災レホチ権輝モエフ会割もフ響3現エツ文時しだびほ経機ムイメフ敗文ヨク現義なさド請情ゆじょて憶主管州けでふく。排ゃわつげ美刊ヱミ出見ツ南者オ抜豆ハトロネ論索モネニイ任償スヲ話破リヤヨ秒止口イセソス止央のさ食周健でてつだ官送ト読聴遊容ひるべ。際ぐドらづ市居ネムヤ研校35岩6繹ごわク報拐イ革深52球ゃレスご究東スラ衝3間ラ録占たス。
 
-	dataWithMissingValues := []string{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "", ""}
+禁にンご忘康ざほぎル騰般ねど事超スんいう真表何カモ自浩ヲシミ図客線るふ静王ぱーま写村月掛焼詐面ぞゃ。昇強ごントほ価保キ族85岡モテ恋困ひりこな刊並せご出来ぼぎむう点目ヲウ止環公ニレ事応タス必書タメムノ当84無信升ちひょ。価ーぐ中客テサ告覧ヨトハ極整ラ得95稿はかラせ江利ス宏丸霊ミ考整ス静将ず業巨職ノラホ収嗅ざな。`,
+					"شيء قد للحكومة والكوري الأوروبيّون, بوابة تعديل واعتلاء ضرب بـ. إذ أسر اتّجة اعلان, ٣٠ اكتوبر العصبة استمرار ومن. أفاق للسيطرة التاريخ، مع بحث, كلّ اتّجة القوى مع. فبعد ايطاليا، تم حتى, لكل تم جسيمة الإحتفاظ وباستثناء, عل فرنسا وانتهاءً الإقتصادية عرض. ونتج دأبوا إحكام بال إذ. لغات عملية وتم مع, وصل بداية وبغطاء البرية بل, أي قررت بلاده فكانت حدى",
+					"版応道潟部中幕爆営報門案名見壌府。博健必権次覧編仕断青場内凄新東深簿代供供。守聞書神秀同浜東波恋闘秀。未格打好作器来利阪持西焦朝三女。権幽問季負娘購合旧資健載員式活陸。未倍校朝遺続術吉迎暮広知角亡志不説空住。法省当死年勝絡聞方北投健。室分性山天態意画詳知浅方裁。変激伝阜中野品省載嗅闘額端反。中必台際造事寄民経能前作臓",
+					"각급 선거관리위원회의 조직·직무범위 기타 필요한 사항은 법률로 정한다. 임시회의 회기는 30일을 초과할 수 없다. 국가는 여자의 복지와 권익의 향상을 위하여 노력하여야 한다. 국군의 조직과 편성은 법률로 정한다.",
+				},
+			},
+		},
+	}
 
-	tableWithMissingValues := New().
-		Width(80).
-		Headers("Name", "Description", "Type", "Required", "Default").
-		Row(dataWithMissingValues...)
-	//		StyleFunc(func(_, col int) lipgloss.Style {
-	//			if len(dataWithMissingValues[col]) > 25 {
-	//				return lipgloss.NewStyle().Width(60)
-	//			}
-	//			return lipgloss.NewStyle()
-	//		})
-	//		Row("command", lipgloss.NewStyle().Width(60).Render("A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures."), "yes")
-	tableWithMissingValues.Width(80)
+	for _, tc := range tests {
+		table := New().
+			Headers(tc.headers...).
+			Rows(tc.data...)
+			//		StyleFunc(func(_, col int) lipgloss.Style {
+			//			if len(data[col]) > 25 {
+			//				return lipgloss.NewStyle().Width(30)
+			//			}
+			//			return lipgloss.NewStyle()
+			//		})
+		//		table.Row("command", lipgloss.NewStyle().Width(60).Render("A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures."), "yes")
+		table.Width(80)
 
-	t.Log(lipgloss.Width(tableWithMissingValues.String()))
-	t.Log("\n" + tableWithMissingValues.String() + "\n")
+		t.Log(lipgloss.Width(table.String()))
+		t.Log("\n" + table.String() + "\n")
+	}
+}
+
+func TestContentWrapping_WithPadding(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+		data    [][]string
+	}{
+		{
+			"long row content",
+			[]string{"Name", "Description", "Type", "Required", "Default"},
+			[][]string{{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "hello", "yep"}},
+		},
+		{
+			"missing row content",
+			[]string{"Name", "Description", "Type", "Required", "Default"},
+			[][]string{{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "", ""}},
+		},
+		{
+			"long header content, long and short rows",
+			[]string{"Destination", "Why are you going on this trip? Is it a hot or cold climate?", "Affordability"},
+			[][]string{
+				{"Mexico", "I want to go somewhere hot, dry, and affordable. Mexico has really good food, just don't drink tap water!", "$"},
+				{"New York", "I'm thinking about going during the Christmas season to check out Rockefeller center. Might be cold though...", "$$$"},
+				{"California", "", "$$$"},
+			},
+		},
+		{
+			"Long text, different languages",
+			[]string{"Hello", "你好", "مرحبًا", "안녕하세요"},
+			[][]string{
+				{
+					"",
+					`耐許ヱヨカハ調出あゆ監件び理別よン國給災レホチ権輝モエフ会割もフ響3現エツ文時しだびほ経機ムイメフ敗文ヨク現義なさド請情ゆじょて憶主管州けでふく。排ゃわつげ美刊ヱミ出見ツ南者オ抜豆ハトロネ論索モネニイ任償スヲ話破リヤヨ秒止口イセソス止央のさ食周健でてつだ官送ト読聴遊容ひるべ。際ぐドらづ市居ネムヤ研校35岩6繹ごわク報拐イ革深52球ゃレスご究東スラ衝3間ラ録占たス。
+
+禁にンご忘康ざほぎル騰般ねど事超スんいう真表何カモ自浩ヲシミ図客線るふ静王ぱーま写村月掛焼詐面ぞゃ。昇強ごントほ価保キ族85岡モテ恋困ひりこな刊並せご出来ぼぎむう点目ヲウ止環公ニレ事応タス必書タメムノ当84無信升ちひょ。価ーぐ中客テサ告覧ヨトハ極整ラ得95稿はかラせ江利ス宏丸霊ミ考整ス静将ず業巨職ノラホ収嗅ざな。`,
+					"شيء قد للحكومة والكوري الأوروبيّون, بوابة تعديل واعتلاء ضرب بـ. إذ أسر اتّجة اعلان, ٣٠ اكتوبر العصبة استمرار ومن. أفاق للسيطرة التاريخ، مع بحث, كلّ اتّجة القوى مع. فبعد ايطاليا، تم حتى, لكل تم جسيمة الإحتفاظ وباستثناء, عل فرنسا وانتهاءً الإقتصادية عرض. ونتج دأبوا إحكام بال إذ. لغات عملية وتم مع, وصل بداية وبغطاء البرية بل, أي قررت بلاده فكانت حدى",
+					"版応道潟部中幕爆営報門案名見壌府。博健必権次覧編仕断青場内凄新東深簿代供供。守聞書神秀同浜東波恋闘秀。未格打好作器来利阪持西焦朝三女。権幽問季負娘購合旧資健載員式活陸。未倍校朝遺続術吉迎暮広知角亡志不説空住。法省当死年勝絡聞方北投健。室分性山天態意画詳知浅方裁。変激伝阜中野品省載嗅闘額端反。中必台際造事寄民経能前作臓",
+					"각급 선거관리위원회의 조직·직무범위 기타 필요한 사항은 법률로 정한다. 임시회의 회기는 30일을 초과할 수 없다. 국가는 여자의 복지와 권익의 향상을 위하여 노력하여야 한다. 국군의 조직과 편성은 법률로 정한다.",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		table := New().
+			Headers(tc.headers...).
+			Rows(tc.data...).
+			StyleFunc(func(_, col int) lipgloss.Style {
+				return lipgloss.NewStyle().Padding(0, 1)
+			})
+		table.Width(80)
+
+		t.Log(lipgloss.Width(table.String()))
+		t.Log("\n" + table.String() + "\n")
+	}
+}
+
+func TestContentWrapping_WithMargins(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+		data    [][]string
+	}{
+		{
+			"long row content",
+			[]string{"Name", "Description", "Type", "Required", "Default"},
+			[][]string{{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "hello", "yep"}},
+		},
+		{
+			"missing row content",
+			[]string{"Name", "Description", "Type", "Required", "Default"},
+			[][]string{{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "", ""}},
+		},
+		{
+			"long header content, long and short rows",
+			[]string{"Destination", "Why are you going on this trip? Is it a hot or cold climate?", "Affordability"},
+			[][]string{
+				{"Mexico", "I want to go somewhere hot, dry, and affordable. Mexico has really good food, just don't drink tap water!", "$"},
+				{"New York", "I'm thinking about going during the Christmas season to check out Rockefeller center. Might be cold though...", "$$$"},
+				{"California", "", "$$$"},
+			},
+		},
+		{
+			"Long text, different languages",
+			[]string{"Hello", "你好", "مرحبًا", "안녕하세요"},
+			[][]string{
+				{
+					"Lorem ipsum dolor sit amet, regione detracto eos an. Has ei quidam hendrerit intellegebat, id tamquam iudicabit necessitatibus ius, at errem officiis hendrerit mei. Exerci noster at has, sit id tota convenire, vel ex rebum inciderint liberavisse. Quaeque delectus corrumpit cu cum.",
+					`耐許ヱヨカハ調出あゆ監件び理別よン國給災レホチ権輝モエフ会割もフ響3現エツ文時しだびほ経機ムイメフ敗文ヨク現義なさド請情ゆじょて憶主管州けでふく。排ゃわつげ美刊ヱミ出見ツ南者オ抜豆ハトロネ論索モネニイ任償スヲ話破リヤヨ秒止口イセソス止央のさ食周健でてつだ官送ト読聴遊容ひるべ。際ぐドらづ市居ネムヤ研校35岩6繹ごわク報拐イ革深52球ゃレスご究東スラ衝3間ラ録占たス。
+
+禁にンご忘康ざほぎル騰般ねど事超スんいう真表何カモ自浩ヲシミ図客線るふ静王ぱーま写村月掛焼詐面ぞゃ。昇強ごントほ価保キ族85岡モテ恋困ひりこな刊並せご出来ぼぎむう点目ヲウ止環公ニレ事応タス必書タメムノ当84無信升ちひょ。価ーぐ中客テサ告覧ヨトハ極整ラ得95稿はかラせ江利ス宏丸霊ミ考整ス静将ず業巨職ノラホ収嗅ざな。`,
+					"شيء قد للحكومة والكوري الأوروبيّون, بوابة تعديل واعتلاء ضرب بـ. إذ أسر اتّجة اعلان, ٣٠ اكتوبر العصبة استمرار ومن. أفاق للسيطرة التاريخ، مع بحث, كلّ اتّجة القوى مع. فبعد ايطاليا، تم حتى, لكل تم جسيمة الإحتفاظ وباستثناء, عل فرنسا وانتهاءً الإقتصادية عرض. ونتج دأبوا إحكام بال إذ. لغات عملية وتم مع, وصل بداية وبغطاء البرية بل, أي قررت بلاده فكانت حدى",
+					"版応道潟部中幕爆営報門案名見壌府。博健必権次覧編仕断青場内凄新東深簿代供供。守聞書神秀同浜東波恋闘秀。未格打好作器来利阪持西焦朝三女。権幽問季負娘購合旧資健載員式活陸。未倍校朝遺続術吉迎暮広知角亡志不説空住。法省当死年勝絡聞方北投健。室分性山天態意画詳知浅方裁。変激伝阜中野品省載嗅闘額端反。中必台際造事寄民経能前作臓",
+					"각급 선거관리위원회의 조직·직무범위 기타 필요한 사항은 법률로 정한다. 임시회의 회기는 30일을 초과할 수 없다. 국가는 여자의 복지와 권익의 향상을 위하여 노력하여야 한다. 국군의 조직과 편성은 법률로 정한다.",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		table := New().
+			Headers(tc.headers...).
+			Rows(tc.data...).
+			StyleFunc(func(_, col int) lipgloss.Style {
+				return lipgloss.NewStyle().Margin(0, 1)
+			})
+		table.Width(80)
+
+		t.Log(lipgloss.Width(table.String()))
+		t.Log("\n" + table.String() + "\n")
+	}
+}
+
+func TestContentTableWriter(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+		data    [][]string
+	}{
+		{
+			"long row content",
+			[]string{"Name", "Description", "Type", "Required", "Default"},
+			[][]string{{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "hello", "yep"}},
+		},
+		{
+			"missing row content",
+			[]string{"Name", "Description", "Type", "Required", "Default"},
+			[][]string{{"command", "A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.", "yes", "", ""}},
+		},
+		{
+			"long header content, long and short rows",
+			[]string{"Destination", "Why are you going on this trip? Is it a hot or cold climate?", "Affordability"},
+			[][]string{
+				{"Mexico", "I want to go somewhere hot, dry, and affordable. Mexico has really good food, just don't drink tap water!", "$"},
+				{"New York", "I'm thinking about going during the Christmas season to check out Rockefeller center. Might be cold though...", "$$$"},
+				{"California", "", "$$$"},
+			},
+		},
+		{
+			"Long text, different languages",
+			[]string{"Hello", "你好", "مرحبًا", "안녕하세요"},
+			[][]string{
+				{
+					"",
+					`耐許ヱヨカハ調出あゆ監件び理別よン國給災レホチ権輝モエフ会割もフ響3現エツ文時しだびほ経機ムイメフ敗文ヨク現義なさド請情ゆじょて憶主管州けでふく。排ゃわつげ美刊ヱミ出見ツ南者オ抜豆ハトロネ論索モネニイ任償スヲ話破リヤヨ秒止口イセソス止央のさ食周健でてつだ官送ト読聴遊容ひるべ。際ぐドらづ市居ネムヤ研校35岩6繹ごわク報拐イ革深52球ゃレスご究東スラ衝3間ラ録占たス。
+
+禁にンご忘康ざほぎル騰般ねど事超スんいう真表何カモ自浩ヲシミ図客線るふ静王ぱーま写村月掛焼詐面ぞゃ。昇強ごントほ価保キ族85岡モテ恋困ひりこな刊並せご出来ぼぎむう点目ヲウ止環公ニレ事応タス必書タメムノ当84無信升ちひょ。価ーぐ中客テサ告覧ヨトハ極整ラ得95稿はかラせ江利ス宏丸霊ミ考整ス静将ず業巨職ノラホ収嗅ざな。`,
+					"شيء قد للحكومة والكوري الأوروبيّون, بوابة تعديل واعتلاء ضرب بـ. إذ أسر اتّجة اعلان, ٣٠ اكتوبر العصبة استمرار ومن. أفاق للسيطرة التاريخ، مع بحث, كلّ اتّجة القوى مع. فبعد ايطاليا، تم حتى, لكل تم جسيمة الإحتفاظ وباستثناء, عل فرنسا وانتهاءً الإقتصادية عرض. ونتج دأبوا إحكام بال إذ. لغات عملية وتم مع, وصل بداية وبغطاء البرية بل, أي قررت بلاده فكانت حدى",
+					"版応道潟部中幕爆営報門案名見壌府。博健必権次覧編仕断青場内凄新東深簿代供供。守聞書神秀同浜東波恋闘秀。未格打好作器来利阪持西焦朝三女。権幽問季負娘購合旧資健載員式活陸。未倍校朝遺続術吉迎暮広知角亡志不説空住。法省当死年勝絡聞方北投健。室分性山天態意画詳知浅方裁。変激伝阜中野品省載嗅闘額端反。中必台際造事寄民経能前作臓",
+					"각급 선거관리위원회의 조직·직무범위 기타 필요한 사항은 법률로 정한다. 임시회의 회기는 30일을 초과할 수 없다. 국가는 여자의 복지와 권익의 향상을 위하여 노력하여야 한다. 국군의 조직과 편성은 법률로 정한다.",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader(tc.headers)
+
+		for _, v := range tc.data {
+			table.Append(v)
+		}
+
+		table.Render()
+	}
 }
 
 func TestCarriageReturn(t *testing.T) {

--- a/table/util.go
+++ b/table/util.go
@@ -38,7 +38,9 @@ func sum(n []int) int {
 }
 
 // median returns the median of a slice of integers.
-func median(n []int) int {
+func median(original []int) int {
+	// Don't modify the original array.
+	n := append([]int{}, original...)
 	sort.Ints(n)
 
 	if len(n) <= 0 {

--- a/table/util.go
+++ b/table/util.go
@@ -48,7 +48,8 @@ func median(original []int) int {
 	}
 	if len(n)%2 == 0 {
 		h := len(n) / 2            //nolint:gomnd
-		return (n[h-1] + n[h]) / 2 //nolint:gomnd
+		tmp := (n[h-1] + n[h]) / 2 //nolint:gomnd
+		return tmp
 	}
 	return n[len(n)/2]
 }


### PR DESCRIPTION
This PR fixes improper content truncation in lipgloss table. See https://github.com/charmbracelet/glamour/issues/344

You can run `go test -run TestContentWrapping -v` to see the current output

before:
![image](https://github.com/user-attachments/assets/9834f991-97c9-4235-ab69-f1365c1dd59e)

current:
![image](https://github.com/user-attachments/assets/9d8beaef-374a-475c-a2f7-d1993e767fa2)

TODO:
- [ ] wrap headers if they're long?
- [ ] wrap content if no height is set?
- [ ] more tests for edge cases (wip)