### PR TITLE
(v2) compositing API edit: no ID argument

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -32,15 +32,15 @@ func (c *Canvas) Bounds() image.Rectangle {
 	return c.buf.Bounds()
 }
 
-// Hit returns the [Layer.ID] at the given point. If no Layer is found, it
-// returns an empty string.
-func (c *Canvas) Hit(x, y int) string {
+// Hit returns the [Layer.ID] at the given point. If no Layer is found,
+// nil is returned.
+func (c *Canvas) Hit(x, y int) *Layer {
 	for i := len(c.layers) - 1; i >= 0; i-- {
 		if c.layers[i].InBounds(x, y) {
 			return c.layers[i].Hit(x, y)
 		}
 	}
-	return ""
+	return nil
 }
 
 // AddLayers adds the given layers to the Canvas.
@@ -49,8 +49,8 @@ func (c *Canvas) AddLayers(layers ...*Layer) {
 	sortLayers(c.layers, false)
 }
 
-// Get returns the Layer with the given ID. If the ID is not found, it returns
-// nil.
+// Get returns the Layer with the given ID. If the ID is not found, nil is
+// returned.
 func (c *Canvas) Get(id string) *Layer {
 	for _, l := range c.layers {
 		if la := l.Get(id); la != nil {
@@ -132,9 +132,9 @@ func (l *Layer) Bounds() image.Rectangle {
 	return l.rect
 }
 
-// Hit returns the [Layer.ID] at the given point. If no Layer is found, it
-// returns an empty string.
-func (l *Layer) Hit(x, y int) string {
+// Hit returns the [Layer.ID] at the given point. If no Layer is found,
+// returns nil is returned.
+func (l *Layer) Hit(x, y int) *Layer {
 	// Reverse the order of the layers so that the top-most layer is checked
 	// first.
 	for i := len(l.children) - 1; i >= 0; i-- {
@@ -144,10 +144,10 @@ func (l *Layer) Hit(x, y int) string {
 	}
 
 	if image.Pt(x, y).In(l.Bounds()) {
-		return l.id
+		return l
 	}
 
-	return ""
+	return nil
 }
 
 // ID sets the ID of the Layer. The ID can be used to identify the Layer when

--- a/canvas.go
+++ b/canvas.go
@@ -113,9 +113,8 @@ type Layer struct {
 
 // NewLayer creates a new Layer with the given content. It calculates the size
 // based on the widest line and the number of lines in the content.
-func NewLayer(id, content string) (l *Layer) {
+func NewLayer(content string) (l *Layer) {
 	l = new(Layer)
-	l.id = id
 	l.content = content
 	height := Height(content)
 	width := Width(content)
@@ -151,7 +150,8 @@ func (l *Layer) Hit(x, y int) string {
 	return ""
 }
 
-// ID sets the ID of the Layer.
+// ID sets the ID of the Layer. The ID can be used to identify the Layer when
+// performing hit tests.
 func (l *Layer) ID(id string) *Layer {
 	l.id = id
 	return l

--- a/examples/clickable/main.go
+++ b/examples/clickable/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss/v2"
@@ -230,7 +228,10 @@ func (m model) Composite() *lipgloss.Canvas {
 	)
 
 	layers := make([]*lipgloss.Layer, len(m.dialogs)+1)
-	layers[0] = lipgloss.NewLayer("bg", bg).Width(m.width).Height(m.height)
+	layers[0] = lipgloss.NewLayer(bg).
+		ID("bg").
+		Width(m.width).
+		Height(m.height)
 
 	for i, d := range m.dialogs {
 		layers[i+1] = d.view().Z(i + 1)
@@ -310,11 +311,13 @@ func (d dialog) view() *lipgloss.Layer {
 	buttonX := lipgloss.Width(window) - lipgloss.Width(button) - 1 - hGap
 	buttonY := lipgloss.Height(window) - lipgloss.Height(button) - 1 - vGap
 
-	buttonLayer := lipgloss.NewLayer(d.buttonID, button).
+	buttonLayer := lipgloss.NewLayer(button).
+		ID(d.buttonID).
 		X(buttonX).
 		Y(buttonY)
 
-	return lipgloss.NewLayer(d.id, window).
+	return lipgloss.NewLayer(window).
+		ID(d.id).
 		X(d.x).
 		Y(d.y).
 		AddLayers(buttonLayer)
@@ -323,7 +326,6 @@ func (d dialog) view() *lipgloss.Layer {
 // Main
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
 	ksuid.SetRand(ksuid.FastRander)
 
 	path := os.Getenv("TEA_LOGFILE")

--- a/examples/clickable/main.go
+++ b/examples/clickable/main.go
@@ -100,16 +100,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Initial press
 			if !m.mouseDown {
 				m.mouseDown = true
-				m.pressID = hit
+				m.pressID = ""
+				if hit != nil {
+					m.pressID = hit.GetID()
+				}
 
 				// Did we press on a dialog box?
 				for i, d := range m.dialogs {
-					if d.id != hit {
+					if hit != nil && d.id != hit.GetID() {
 						continue
 					}
 
 					// Init drag
-					m.dragID = hit
+					m.dragID = hit.GetID()
 					m.dragOffsetX = mouse.X - d.x
 					m.dragOffsetY = mouse.Y - d.y
 
@@ -158,11 +161,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				d.hovering = false
 				d.hoveringButton = false
 
-				if d.id == hit {
+				if d.id == hit.GetID() {
 					d.hovering = true
 					continue
 				}
-				if d.buttonID == hit {
+				if d.buttonID == hit.GetID() {
 					d.hovering = true
 					d.hoveringButton = true
 					continue
@@ -179,7 +182,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Did we click a button?
 			for i, d := range m.dialogs {
-				if hit == d.buttonID && m.pressID == d.buttonID {
+				if hit.GetID() == d.buttonID && m.pressID == d.buttonID {
 					// "Close" the window
 					m.dialogs = m.removeDialog(i)
 					break
@@ -187,7 +190,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			// Clicking the background spawns a new dialog
-			if hit == "bg" && m.pressID == "bg" {
+			if hit.GetID() == "bg" && m.pressID == "bg" {
 				if len(m.dialogs) < maxDialogs {
 					m.dialogs = append(m.dialogs, m.newDialog(mouse.X, mouse.Y))
 				}

--- a/examples/layout/main.go
+++ b/examples/layout/main.go
@@ -203,6 +203,15 @@ func main() {
 
 		fishCakeStyle = statusNugget.Background(lipgloss.Color("#6124DF"))
 
+		// Floating thing.
+
+		floatingStyle = lipgloss.NewStyle().
+				Italic(true).
+				Foreground(lipgloss.Color("#FFF7DB")).
+				Background(lipgloss.Color("#F25D94")).
+				Padding(1, 6).
+				Align(lipgloss.Center)
+
 		// Page.
 
 		docStyle = lipgloss.NewStyle().Padding(1, 2, 1, 2)
@@ -370,10 +379,20 @@ func main() {
 		docStyle = docStyle.MaxWidth(physicalWidth)
 	}
 
+	// Render the document.
+	document := docStyle.Render(doc.String())
+
+	// Surprise! Composite some bonus content on top of the document.
+	modal := floatingStyle.Render("Now with Compositing!")
+	canvas := lipgloss.NewCanvas(
+		lipgloss.NewLayer(document),
+		lipgloss.NewLayer(modal).X(58).Y(44),
+	)
+
 	// Okay, let's print it. We use a special Lipgloss writer to downsample
 	// colors to the terminal's color palette. And, if output's not a TTY, we
 	// will remove color entirely.
-	lipgloss.Println(docStyle.Render(doc.String()))
+	lipgloss.Println(canvas.Render())
 }
 
 func colorGrid(xSteps, ySteps int) [][]string {


### PR DESCRIPTION
This series of revisions:

* Removes the ID argument from `NewLayer`
* Changes `Canvas` and `Layer` hit tests to return `Layer`s
* Adds compositing to the `layout` example.