### PR TITLE
docs: fix table example on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,17 +425,28 @@ rows := [][]string{
 Use the table package to style and render the table.
 
 ```go
+var (
+    purple    = lipgloss.Color("99")
+    gray      = lipgloss.Color("245")
+    lightGray = lipgloss.Color("241")
+
+    headerStyle  = lipgloss.NewStyle().Foreground(purple).Bold(true).Align(lipgloss.Center)
+    cellStyle    = lipgloss.NewStyle().Padding(0, 1).Width(14)
+    oddRowStyle  = cellStyle.Foreground(gray)
+    evenRowStyle = cellStyle.Foreground(lightGray)
+)
+
 t := table.New().
     Border(lipgloss.NormalBorder()).
-    BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("99"))).
+    BorderStyle(lipgloss.NewStyle().Foreground(purple)).
     StyleFunc(func(row, col int) lipgloss.Style {
         switch {
-        case row == 0:
-            return HeaderStyle
+        case row == table.HeaderRow:
+            return headerStyle
         case row%2 == 0:
-            return EvenRowStyle
+            return evenRowStyle
         default:
-            return OddRowStyle
+            return oddRowStyle
         }
     }).
     Headers("LANGUAGE", "FORMAL", "INFORMAL").


### PR DESCRIPTION
1. The header index is actually `-1` and not `0`. Checking for the `table.HeaderRow` const which is set to `-1`.
1. Adding the style definitions so the example is actually complete and can be copy & pasted and ran more easily.