### PR TITLE
fix: use non-breaking space for padding

### DIFF
--- a/style.go
+++ b/style.go
@@ -524,7 +524,9 @@ func pad(str string, n int, style *ansi.Style) string {
 		return str
 	}
 
-	sp := strings.Repeat(" ", abs(n))
+	// We use a non-breaking space to pad so that the padding is
+	// preserved when the string is copied and pasted.
+	sp := strings.Repeat("\u00a0", abs(n))
 	if style != nil {
 		sp = style.Styled(sp)
 	}


### PR DESCRIPTION
Padding should use a non-breaking space so that the padding is preserved when the string is being copied and pasted, and wrapped to the next line.