### PR TITLE
fix(table): fix resizer ignoring borders when deciding whether to shrink

### DIFF
--- a/table/resizing.go
+++ b/table/resizing.go
@@ -360,7 +360,8 @@ func (r *resizer) maxCharCount() int {
 }
 
 // maxTotal returns the maximum total width.
-func (r *resizer) maxTotal() (maxTotal int) {
+func (r *resizer) maxTotal() int {
+	maxTotal := r.totalHorizontalBorder()
 	for j, column := range r.columns {
 		if column.fixedWidth > 0 {
 			maxTotal += column.fixedWidth


### PR DESCRIPTION
### Describe your changes

`resizer.maxTotal()` is compared to `r.tableWidth` within `resizer.optimizedWidths()` to decide whether to shrink or expand the column sizes according to the available space.

Unfortunately, `maxTotal()` only takes into account the column sizes (fixed width if specified, max character count + padding otherwise), ignoring the space taken up by borders.

This leads to the table resizing breaking as follows: if a table has 1 column with a max character count of 10:
- Setting a table width < 8 works as expected
- Setting a table width >= 8 && < 10 leads to `expandTableWidth()` being called even if the table needed to be shrunk, causing the contents to be cut off
- Setting a table width > 10 works as expected

Change `maxTotal()` to include `r.totalHorizontalBorder()` so that borders are taken into account and the table is shrunk up until the width where borders + column widths fit.

### Related issue/discussion: none

### Checklist before requesting a review

- [x] I have read `CONTRIBUTING.md`
- [x] I have performed a self-review of my code