### PR TITLE
do not swap start and end in tree Offset function

### DIFF
--- a/tree/tree.go
+++ b/tree/tree.go
@@ -119,12 +119,6 @@ func (t *Tree) SetHidden(hidden bool) { t.Hide(hidden) }
 
 // Offset sets the Tree children offsets.
 func (t *Tree) Offset(start, end int) *Tree {
-	if start > end {
-		_start := start
-		start = end
-		end = _start
-	}
-
 	if start < 0 {
 		start = 0
 	}


### PR DESCRIPTION
### Describe your changes
Remove code for swapping the start and end values if start > end from the Tree Offset function.

### Related issue/discussion: <insert link>
[Tree Offset logic is broken](https://github.com/charmbracelet/lipgloss/issues/535)

### Checklist before requesting a review

- [*] I have read `CONTRIBUTING.md`
- [*] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
