### PR TITLE
chore: retract v2.0.0-beta1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ retract v0.7.0 // v0.7.0 introduces a bug that causes some apps to freeze.
 
 retract v0.11.1 // v0.11.1 uses a broken version of x/ansi StringWidth that causes some lines to wrap incorrectly.
 
+retract v2.0.0-beta1 // We add a "." after the "beta" in the version number.
+
 go 1.23.0
 
 require (


### PR DESCRIPTION
it is already retracted in the `v2-exp` branch, but it doesn't seem to be working.

I think we might need to add it on `master` as well, and maybe cut a release.

Another possibility is that go's version resolution always thinks `beta1 > beta.<any number>`, in which case I don't know what we can do 🤔  

See: https://go.dev/blog/go116-module-changes#module-retraction