### PR TITLE
feat: colors sub-package: color blending & other low-level color utilities

### DIFF
--- a/colors/blending.go
+++ b/colors/blending.go
@@ -1,0 +1,194 @@
+package colors
+
+import (
+	"image/color"
+	"math"
+	"slices"
+
+	"github.com/lucasb-eyer/go-colorful"
+)
+
+// BlendLinear1D blends a series of colors together in one linear dimension using multiple
+// stops, into the provided number of steps. Uses the "CIE L*, a*, b*" (CIELAB) color-space.
+//
+// Note that if any of the provided colors are completely transparent, we will
+// assume that the alpha value was lost in conversion from RGB -> RGBA, and we
+// will set the alpha to opaque, as it's not possible to blend something completely
+// transparent.
+func BlendLinear1D(steps int, stops ...color.Color) []color.Color {
+	// Bound to a minimum of 2 steps. If they only provided one, it's actually invalid,
+	// but will ensure that we don't panic.
+	if steps < 2 {
+		steps = 2
+	}
+
+	// Ensure they didn't provide any nil colors.
+	stops = slices.DeleteFunc(stops, func(c color.Color) bool {
+		return c == nil
+	})
+
+	if len(stops) == 0 {
+		return nil // We can't safely fallback.
+	}
+
+	// If they only provided one valid color (or some nil colors), we will just return
+	// an array of that color, for the amount of steps they requested.
+	if len(stops) == 1 {
+		singleColor := stops[0]
+		result := make([]color.Color, steps)
+		for i := range result {
+			result[i] = singleColor
+		}
+		return result
+	}
+
+	blended := make([]color.Color, steps)
+
+	// Convert stops to colorful.Color once
+	cstops := make([]colorful.Color, len(stops))
+	for i, k := range stops {
+		cstops[i], _ = colorful.MakeColor(ensureNotTransparent(k))
+	}
+
+	numSegments := len(cstops) - 1
+	defaultSize := steps / numSegments
+	remainingSteps := steps % numSegments
+
+	resultIndex := 0
+	for i := range numSegments {
+		from := cstops[i]
+		to := cstops[i+1]
+
+		// Calculate segment size.
+		segmentSize := defaultSize
+		if i < remainingSteps {
+			segmentSize++
+		}
+
+		divisor := float64(segmentSize - 1)
+
+		// Generate colors for this segment.
+		for j := 0; j < segmentSize; j++ {
+			var blendingFactor float64
+			if segmentSize > 1 {
+				blendingFactor = float64(j) / divisor
+			}
+			blended[resultIndex] = from.BlendLab(to, blendingFactor).Clamped()
+			resultIndex++
+		}
+	}
+
+	return blended
+}
+
+// BlendLinear2D blends a series of colors together in two linear dimensions using
+// multiple stops, into the provided width/height. Uses the "CIE L*, a*, b*" (CIELAB)
+// color-space. The angle parameter controls the rotation of the gradient (0-360°),
+// where 0° is left-to-right, 45° is bottom-left to top-right (diagonal). The function
+// returns colors in a 1D row-major order ([row1, row2, row3, ...]).
+//
+// Example of how to iterate over the result:
+//
+//	gradient := colors.BlendLinear2D(width, height, 180, color1, color2, color3, ...)
+//	gradientContent := strings.Builder{}
+//	for y := range height {
+//		for x := range width {
+//			index := y*width + x
+//			gradientContent.WriteString(
+//				lipgloss.NewStyle().
+//					Background(gradient[index]).
+//					Render(" "),
+//			)
+//		}
+//		if y < height-1 { // End of row.
+//			gradientContent.WriteString("\n")
+//		}
+//	}
+//
+// Note that if any of the provided colors are completely transparent, we will
+// assume that the alpha value was lost in conversion from RGB -> RGBA, and we
+// will set the alpha to opaque, as it's not possible to blend something completely
+// transparent.
+func BlendLinear2D(width, height, angle int, stops ...color.Color) []color.Color {
+	if width < 1 {
+		width = 1
+	}
+	if height < 1 {
+		height = 1
+	}
+
+	// Normalize angle to 0-360.
+	angle = angle % 360
+	if angle < 0 {
+		angle += 360
+	}
+
+	// Ensure they didn't provide any nil colors.
+	stops = slices.DeleteFunc(stops, func(c color.Color) bool {
+		return c == nil
+	})
+
+	if len(stops) == 0 {
+		return nil // We can't safely fallback.
+	}
+
+	// If they only provided one valid color (or some nil colors), we will just return
+	// an array of that color, for the amount of pixels they requested.
+	if len(stops) == 1 {
+		singleColor := stops[0]
+		result := make([]color.Color, width*height)
+		for i := range result {
+			result[i] = singleColor
+		}
+		return result
+	}
+
+	// For 2D blending, we'll create a gradient along the diagonal and then sample
+	// from it based on the angle. We'll use the maximum dimension to ensure we have
+	// enough resolution for the gradient.
+	diagonalGradient := BlendLinear1D(max(width, height), stops...)
+
+	result := make([]color.Color, width*height)
+
+	// Calculate center point for rotation.
+	centerX := float64(width-1) / 2.0
+	centerY := float64(height-1) / 2.0
+
+	angleRad := float64(angle) * math.Pi / 180.0 // -> radians.
+
+	// Pre-calculate sin and cos.
+	cosAngle := math.Cos(angleRad)
+	sinAngle := math.Sin(angleRad)
+
+	// Calculate diagonal length for proper gradient mapping.
+	diagonalLength := math.Sqrt(float64(width*width + height*height))
+
+	// Pre-calculate gradient length for index calculation.
+	gradientLen := float64(len(diagonalGradient) - 1)
+
+	for y := range height {
+		// Calculate the distance from center along the gradient direction.
+		dy := float64(y) - centerY
+
+		for x := 0; x < width; x++ {
+			// Calculate the distance from center along the gradient direction.
+			dx := float64(x) - centerX
+
+			rotX := dx*cosAngle - dy*sinAngle // Rotate the point by the angle.
+
+			// Map the rotated position to the gradient. Normalize to 0-1 range based on
+			// the diagonal length.
+			gradientPos := clamp((rotX+diagonalLength/2.0)/diagonalLength, 0, 1)
+
+			// Calculate the index in the gradient.
+			gradientIndex := int(gradientPos * gradientLen)
+			if gradientIndex >= len(diagonalGradient) {
+				gradientIndex = len(diagonalGradient) - 1
+			}
+
+			result[y*width+x] = diagonalGradient[gradientIndex] // -> row-major order.
+		}
+	}
+
+	return result
+}

--- a/colors/blending_test.go
+++ b/colors/blending_test.go
@@ -1,0 +1,341 @@
+package colors
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestBlend(t *testing.T) {
+	tests := []struct {
+		name     string
+		steps    int
+		stops    []color.Color
+		expected []color.Color
+	}{
+		{
+			name:  "2-colors-10-steps",
+			steps: 10,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expected: []color.Color{
+				&color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				&color.RGBA{R: 246, G: 0, B: 45, A: 255},
+				&color.RGBA{R: 235, G: 0, B: 73, A: 255},
+				&color.RGBA{R: 223, G: 0, B: 99, A: 255},
+				&color.RGBA{R: 210, G: 0, B: 124, A: 255},
+				&color.RGBA{R: 193, G: 0, B: 149, A: 255},
+				&color.RGBA{R: 173, G: 0, B: 175, A: 255},
+				&color.RGBA{R: 147, G: 0, B: 201, A: 255},
+				&color.RGBA{R: 109, G: 0, B: 228, A: 255},
+				&color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+		},
+		{
+			name:  "3-colors-4-steps",
+			steps: 4,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 255, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expected: []color.Color{
+				&color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				&color.RGBA{R: 0, G: 255, B: 0, A: 255},
+				&color.RGBA{R: 0, G: 255, B: 0, A: 255},
+				&color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+		},
+		{
+			name:  "black-to-white-5-steps",
+			steps: 5,
+			stops: []color.Color{
+				color.RGBA{R: 0, G: 0, B: 0, A: 255},
+				color.RGBA{R: 255, G: 255, B: 255, A: 255},
+			},
+			expected: []color.Color{
+				&color.RGBA{R: 0, G: 0, B: 0, A: 255},
+				&color.RGBA{R: 59, G: 59, B: 59, A: 255},
+				&color.RGBA{R: 119, G: 119, B: 119, A: 255},
+				&color.RGBA{R: 185, G: 185, B: 185, A: 255},
+				&color.RGBA{R: 255, G: 255, B: 255, A: 255},
+			},
+		},
+		{
+			name:  "4-colors-6-steps",
+			steps: 6,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 255, G: 255, B: 0, A: 255},
+				color.RGBA{R: 0, G: 255, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expected: []color.Color{
+				&color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				&color.RGBA{R: 255, G: 255, B: 0, A: 255},
+				&color.RGBA{R: 255, G: 255, B: 0, A: 255},
+				&color.RGBA{R: 0, G: 255, B: 0, A: 255},
+				&color.RGBA{R: 0, G: 255, B: 0, A: 255},
+				&color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+		},
+		{
+			name:  "2-steps-5-stops",
+			steps: 2,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 255, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+				color.RGBA{R: 255, G: 255, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 0, A: 255},
+			},
+			expected: []color.Color{
+				&color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				&color.RGBA{R: 0, G: 255, B: 0, A: 255},
+			},
+		},
+		{
+			name:  "insufficient-stops",
+			steps: 3,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+			},
+			expected: []color.Color{
+				&color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				&color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				&color.RGBA{R: 255, G: 0, B: 0, A: 255},
+			},
+		},
+		{
+			name:  "insufficient-steps",
+			steps: 1,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expected: []color.Color{
+				&color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				&color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := BlendLinear1D(tt.steps, tt.stops...)
+
+			if len(got) != len(tt.expected) {
+				t.Errorf("Blend() = %v length, want %v length", len(got), len(tt.expected))
+			}
+
+			for i := range tt.expected {
+				expectColorMatches(t, got[i], tt.expected[i])
+			}
+		})
+	}
+}
+
+func TestBlendLinear2D(t *testing.T) {
+	tests := []struct {
+		name           string
+		width, height  int
+		angle          int
+		stops          []color.Color
+		expectedLength int
+	}{
+		{
+			name:   "2x2-red-to-blue-0deg",
+			width:  2,
+			height: 2,
+			angle:  0,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expectedLength: 4,
+		},
+		{
+			name:   "3x2-red-to-blue-90deg",
+			width:  3,
+			height: 2,
+			angle:  90,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expectedLength: 6,
+		},
+		{
+			name:   "2x3-red-to-blue-180deg",
+			width:  2,
+			height: 3,
+			angle:  180,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expectedLength: 6,
+		},
+		{
+			name:   "2x2-red-to-blue-270deg",
+			width:  2,
+			height: 2,
+			angle:  270,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expectedLength: 4,
+		},
+		{
+			name:   "1x1-single-color",
+			width:  1,
+			height: 1,
+			angle:  0,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+			},
+			expectedLength: 1,
+		},
+		{
+			name:   "3-colors-2x2-0deg",
+			width:  2,
+			height: 2,
+			angle:  0,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 255, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expectedLength: 4,
+		},
+		{
+			name:   "invalid-dimensions-fallback",
+			width:  0,
+			height: -1,
+			angle:  0,
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+			},
+			expectedLength: 1,
+		},
+		{
+			name:   "angle-normalization-450",
+			width:  2,
+			height: 2,
+			angle:  450, // Should normalize to 90
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expectedLength: 4,
+		},
+		{
+			name:   "negative-angle-normalization",
+			width:  2,
+			height: 2,
+			angle:  -90, // Should normalize to 270
+			stops: []color.Color{
+				color.RGBA{R: 255, G: 0, B: 0, A: 255},
+				color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			},
+			expectedLength: 4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := BlendLinear2D(tt.width, tt.height, tt.angle, tt.stops...)
+
+			if len(got) != tt.expectedLength {
+				t.Errorf("BlendLinear2D() = %v length, want %v length", len(got), tt.expectedLength)
+			}
+
+			// Verify row-major order by checking that the width matches.
+			if tt.width > 0 && tt.height > 0 {
+				expectedTotal := max(tt.width, 1) * max(tt.height, 1)
+				if len(got) != expectedTotal {
+					t.Errorf("BlendLinear2D() total pixels = %v, want %v", len(got), expectedTotal)
+				}
+			}
+
+			// Verify that we have valid colors (not nil).
+			for i, color := range got {
+				if color == nil {
+					t.Errorf("BlendLinear2D() color at index %d is nil", i)
+				}
+			}
+
+			// For single color tests, verify all colors are the same.
+			if len(tt.stops) == 1 && len(got) > 0 {
+				firstColor := got[0]
+				for _, color := range got {
+					expectColorMatches(t, color, firstColor)
+				}
+			}
+		})
+	}
+}
+
+func TestBlendLinear2DEdgeCases(t *testing.T) {
+	t.Run("nil-stops", func(t *testing.T) {
+		t.Parallel()
+		got := BlendLinear2D(2, 2, 0, nil, nil)
+		if got != nil {
+			t.Errorf("BlendLinear2D() with nil stops = %v, want nil", got)
+		}
+	})
+
+	t.Run("empty-stops", func(t *testing.T) {
+		t.Parallel()
+		got := BlendLinear2D(2, 2, 0)
+		if got != nil {
+			t.Errorf("BlendLinear2D() with empty stops = %v, want nil", got)
+		}
+	})
+
+	t.Run("nil-color-in-stops", func(t *testing.T) {
+		t.Parallel()
+		got := BlendLinear2D(2, 2, 0, color.RGBA{R: 255, G: 0, B: 0, A: 255}, nil, color.RGBA{R: 0, G: 0, B: 255, A: 255})
+		if len(got) != 4 {
+			t.Errorf("BlendLinear2D() with nil color in stops = %v length, want 4", len(got))
+		}
+		// Should still work with the non-nil colors and produce valid colors
+		for i, color := range got {
+			if color == nil {
+				t.Errorf("BlendLinear2D() color at index %d is nil", i)
+			}
+		}
+	})
+}
+
+func BenchmarkBlendLinear1D(b *testing.B) {
+	stops := []color.Color{
+		fromHex("#FF0000"), // Red
+		fromHex("#00FF00"), // Green
+		fromHex("#0000FF"), // Blue
+		fromHex("#FFFF00"), // Yellow
+		fromHex("#FF00FF"), // Magenta
+	}
+
+	for b.Loop() {
+		BlendLinear1D(100, stops...)
+	}
+}
+
+func BenchmarkBlendLinear2D(b *testing.B) {
+	stops := []color.Color{
+		fromHex("#FF0000"), // Red
+		fromHex("#00FF00"), // Green
+		fromHex("#0000FF"), // Blue
+		fromHex("#FFFF00"), // Yellow
+		fromHex("#FF00FF"), // Magenta
+	}
+
+	for b.Loop() {
+		BlendLinear2D(100, 50, 45, stops...)
+	}
+}

--- a/colors/brightness.go
+++ b/colors/brightness.go
@@ -1,0 +1,39 @@
+package colors
+
+import (
+	"image/color"
+)
+
+// Darken takes a color and makes it darker by a specific percentage (0-100, clamped).
+func Darken(c color.Color, percent int) color.Color {
+	if c == nil {
+		return nil
+	}
+
+	mult := 1.0 - clamp(float64(percent), 0, 100)/100.0
+
+	r, g, b, a := c.RGBA()
+	return color.RGBA{
+		R: uint8(float64(r>>8) * mult),
+		G: uint8(float64(g>>8) * mult),
+		B: uint8(float64(b>>8) * mult),
+		A: uint8(min(255, float64(a>>8))),
+	}
+}
+
+// Lighten makes a color lighter by a specific percentage (0-100, clamped).
+func Lighten(c color.Color, percent int) color.Color {
+	if c == nil {
+		return nil
+	}
+
+	add := 255 * (clamp(float64(percent), 0, 100) / 100.0)
+
+	r, g, b, a := c.RGBA()
+	return color.RGBA{
+		R: uint8(min(255, float64(r>>8)+add)),
+		G: uint8(min(255, float64(g>>8)+add)),
+		B: uint8(min(255, float64(b>>8)+add)),
+		A: uint8(min(255, float64(a>>8))),
+	}
+}

--- a/colors/brightness_test.go
+++ b/colors/brightness_test.go
@@ -1,0 +1,124 @@
+package colors
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestDarken(t *testing.T) {
+	tests := []struct {
+		name     string
+		color    color.Color
+		percent  int
+		expected color.Color
+	}{
+		{
+			name:     "darken-white-50-percent",
+			color:    color.RGBA{R: 255, G: 255, B: 255, A: 255},
+			percent:  50,
+			expected: color.RGBA{R: 127, G: 127, B: 127, A: 255},
+		},
+		{
+			name:     "darken-red-25-percent",
+			color:    color.RGBA{R: 255, G: 0, B: 0, A: 255},
+			percent:  25,
+			expected: color.RGBA{R: 191, G: 0, B: 0, A: 255},
+		},
+		{
+			name:     "darken-blue-75-percent",
+			color:    color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			percent:  75,
+			expected: color.RGBA{R: 0, G: 0, B: 63, A: 255},
+		},
+		{
+			name:     "darken-black-10-percent",
+			color:    color.RGBA{R: 0, G: 0, B: 0, A: 255},
+			percent:  10,
+			expected: color.RGBA{R: 0, G: 0, B: 0, A: 255},
+		},
+		{
+			name:     "darken-with-clamp-min",
+			color:    color.RGBA{R: 255, G: 255, B: 255, A: 255},
+			percent:  0,
+			expected: color.RGBA{R: 255, G: 255, B: 255, A: 255},
+		},
+		{
+			name:     "darken-with-clamp-max",
+			color:    color.RGBA{R: 255, G: 255, B: 255, A: 255},
+			percent:  100,
+			expected: color.RGBA{R: 0, G: 0, B: 0, A: 255},
+		},
+		{
+			name:     "darken-nil-color",
+			color:    nil,
+			percent:  50,
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expectColorMatches(t, Darken(tt.color, tt.percent), tt.expected)
+		})
+	}
+}
+
+func TestLighten(t *testing.T) {
+	tests := []struct {
+		name     string
+		color    color.Color
+		percent  int
+		expected color.Color
+	}{
+		{
+			name:     "lighten-black-50-percent",
+			color:    color.RGBA{R: 0, G: 0, B: 0, A: 255},
+			percent:  50,
+			expected: color.RGBA{R: 127, G: 127, B: 127, A: 255},
+		},
+		{
+			name:     "lighten-red-25-percent",
+			color:    color.RGBA{R: 128, G: 0, B: 0, A: 255},
+			percent:  25,
+			expected: color.RGBA{R: 191, G: 63, B: 63, A: 255},
+		},
+		{
+			name:     "lighten-blue-75-percent",
+			color:    color.RGBA{R: 0, G: 0, B: 128, A: 255},
+			percent:  75,
+			expected: color.RGBA{R: 191, G: 191, B: 255, A: 255},
+		},
+		{
+			name:     "lighten-white-10-percent",
+			color:    color.RGBA{R: 255, G: 255, B: 255, A: 255},
+			percent:  10,
+			expected: color.RGBA{R: 255, G: 255, B: 255, A: 255},
+		},
+		{
+			name:     "lighten-with-clamp-min",
+			color:    color.RGBA{R: 0, G: 0, B: 0, A: 255},
+			percent:  0,
+			expected: color.RGBA{R: 0, G: 0, B: 0, A: 255},
+		},
+		{
+			name:     "lighten-with-clamp-max",
+			color:    color.RGBA{R: 0, G: 0, B: 0, A: 255},
+			percent:  100,
+			expected: color.RGBA{R: 255, G: 255, B: 255, A: 255},
+		},
+		{
+			name:     "lighten-nil-color",
+			color:    nil,
+			percent:  50,
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expectColorMatches(t, Lighten(tt.color, tt.percent), tt.expected)
+		})
+	}
+}

--- a/colors/colors.go
+++ b/colors/colors.go
@@ -1,0 +1,62 @@
+// Package colors provides a set of color-related utilities for working with colors.
+// This includes utilities for blending colors, adjusting brightness/alpha, etc.
+package colors
+
+import (
+	"cmp"
+	"image/color"
+
+	"github.com/lucasb-eyer/go-colorful"
+)
+
+func clamp[T cmp.Ordered](v, low, high T) T {
+	return min(high, max(low, v))
+}
+
+// ensureNotTransparent ensures that the alpha value of a color is not 0, and if
+// it is, we will set it to 1. This is useful for when we are converting from
+// RGB -> RGBA, and the alpha value is lost in the conversion for gradient purposes.
+func ensureNotTransparent(c color.Color) color.Color {
+	_, _, _, a := c.RGBA()
+	if a == 0 {
+		return Alpha(c, 1)
+	}
+	return c
+}
+
+// Alpha adjusts the alpha value of a color using a 0-1 (clamped) float scale
+// 0 = transparent, 1 = opaque.
+func Alpha(c color.Color, alpha float64) color.Color {
+	if c == nil {
+		return nil
+	}
+
+	r, g, b, _ := c.RGBA()
+	return color.RGBA{
+		R: uint8(min(255, float64(r>>8))),
+		G: uint8(min(255, float64(g>>8))),
+		B: uint8(min(255, float64(b>>8))),
+		A: uint8(clamp(alpha, 0, 1) * 255),
+	}
+}
+
+// Complementary returns the complementary color (180° away on color wheel) of
+// the given color. This is useful for creating a contrasting color.
+func Complementary(c color.Color) color.Color {
+	if c == nil {
+		return nil
+	}
+
+	// Offset hue by 180°.
+	cf, _ := colorful.MakeColor(ensureNotTransparent(c))
+
+	h, s, v := cf.Hsv()
+	h += 180
+	if h >= 360 {
+		h -= 360
+	} else if h < 0 {
+		h += 360
+	}
+
+	return colorful.Hsv(h, s, v).Clamped()
+}

--- a/colors/colors_test.go
+++ b/colors/colors_test.go
@@ -1,0 +1,187 @@
+package colors
+
+import (
+	"fmt"
+	"image/color"
+	"testing"
+
+	"github.com/lucasb-eyer/go-colorful"
+)
+
+// fromHex converts a color to a hex string. Could use lipgloss.Color() but in the future,
+// this could cause a circular dependency.
+func fromHex(hex string) color.Color {
+	cf, err := colorful.Hex(hex)
+	if err != nil {
+		panic(err)
+	}
+	return cf
+}
+
+func expectColorMatches(t *testing.T, got, want color.Color) {
+	t.Helper()
+
+	if (got == nil) != (want == nil) {
+		t.Errorf("expectColorMatches() = %s, want %s", rgbaString(t, got), rgbaString(t, want))
+	}
+
+	if got == nil {
+		return
+	}
+
+	gr, gg, gb, ga := got.RGBA()
+	wr, wg, wb, wa := want.RGBA()
+
+	gru, ggu, gbu, gau := uint8(gr>>8), uint8(gg>>8), uint8(gb>>8), uint8(ga>>8)
+	wru, wgu, wbu, wau := uint8(wr>>8), uint8(wg>>8), uint8(wb>>8), uint8(wa>>8)
+
+	if gru != wru || ggu != wgu || gbu != wbu || gau != wau {
+		t.Errorf("expectColorMatches() = %s, want %s", rgbaString(t, got), rgbaString(t, want))
+	}
+}
+
+func rgbaString(t *testing.T, c color.Color) string {
+	t.Helper()
+
+	if c == nil {
+		return "nil"
+	}
+
+	r, g, b, a := c.RGBA()
+	return fmt.Sprintf("rgba(%d,%d,%d,%d)", uint8(r>>8), uint8(g>>8), uint8(b>>8), uint8(a>>8))
+}
+
+func TestAlpha(t *testing.T) {
+	tests := []struct {
+		name     string
+		color    color.Color
+		alpha    float64
+		expected color.Color
+	}{
+		{
+			name:     "alpha-full-opacity",
+			color:    color.RGBA{R: 255, G: 0, B: 0, A: 255},
+			alpha:    1.0,
+			expected: color.RGBA{R: 255, G: 0, B: 0, A: 255},
+		},
+		{
+			name:     "alpha-half-opacity",
+			color:    color.RGBA{R: 0, G: 255, B: 0, A: 255},
+			alpha:    0.5,
+			expected: color.RGBA{R: 0, G: 255, B: 0, A: 127},
+		},
+		{
+			name:     "alpha-quarter-opacity",
+			color:    color.RGBA{R: 0, G: 0, B: 255, A: 255},
+			alpha:    0.25,
+			expected: color.RGBA{R: 0, G: 0, B: 255, A: 63},
+		},
+		{
+			name:     "alpha-zero-opacity",
+			color:    color.RGBA{R: 255, G: 255, B: 255, A: 255},
+			alpha:    0.0,
+			expected: color.RGBA{R: 255, G: 255, B: 255, A: 0},
+		},
+		{
+			name:     "alpha-clamp-above-max",
+			color:    color.RGBA{R: 255, G: 0, B: 255, A: 255},
+			alpha:    1.5,
+			expected: color.RGBA{R: 255, G: 0, B: 255, A: 255},
+		},
+		{
+			name:     "alpha-clamp-below-min",
+			color:    color.RGBA{R: 255, G: 255, B: 0, A: 255},
+			alpha:    -0.5,
+			expected: color.RGBA{R: 255, G: 255, B: 0, A: 0},
+		},
+		{
+			name:     "alpha-complex-color",
+			color:    color.RGBA{R: 18, G: 52, B: 86, A: 255},
+			alpha:    0.75,
+			expected: color.RGBA{R: 18, G: 52, B: 86, A: 191},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expectColorMatches(t, Alpha(tt.color, tt.alpha), tt.expected)
+		})
+	}
+}
+
+func TestComplementary(t *testing.T) {
+	tests := []struct {
+		name     string
+		color    color.Color
+		expected color.Color
+	}{
+		{
+			name:     "complementary-red",
+			color:    fromHex("#FF0000"), // Red
+			expected: fromHex("#00FFFF"), // Cyan
+		},
+		{
+			name:     "complementary-green",
+			color:    fromHex("#00FF00"), // Green
+			expected: fromHex("#FF00FF"), // Magenta
+		},
+		{
+			name:     "complementary-blue",
+			color:    fromHex("#0000FF"), // Blue
+			expected: fromHex("#FFFF00"), // Yellow
+		},
+		{
+			name:     "complementary-yellow",
+			color:    fromHex("#FFFF00"), // Yellow
+			expected: fromHex("#0000FF"), // Blue
+		},
+		{
+			name:     "complementary-cyan",
+			color:    fromHex("#00FFFF"), // Cyan
+			expected: fromHex("#FF0000"), // Red
+		},
+		{
+			name:     "complementary-magenta",
+			color:    fromHex("#FF00FF"), // Magenta
+			expected: fromHex("#00FF00"), // Green
+		},
+		{
+			name:     "complementary-black",
+			color:    fromHex("#000000"), // Black
+			expected: fromHex("#000000"), // Black (achromatic, no hue to complement)
+		},
+		{
+			name:     "complementary-white",
+			color:    fromHex("#FFFFFF"), // White
+			expected: fromHex("#FFFFFF"), // White (achromatic, no hue to complement)
+		},
+		{
+			name:     "complementary-gray",
+			color:    fromHex("#808080"), // Gray
+			expected: fromHex("#808080"), // Gray (complementary of gray is gray)
+		},
+		{
+			name:     "complementary-orange",
+			color:    fromHex("#FF8000"), // Orange
+			expected: fromHex("#007FFF"), // Blue-cyan
+		},
+		{
+			name:     "complementary-purple",
+			color:    fromHex("#8000FF"), // Purple
+			expected: fromHex("#7FFF00"), // Lime green
+		},
+		{
+			name:     "complementary-nil-color",
+			color:    nil,
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expectColorMatches(t, Complementary(tt.color), tt.expected)
+		})
+	}
+}

--- a/examples/blending/linear-1d/bubbletea/main.go
+++ b/examples/blending/linear-1d/bubbletea/main.go
@@ -1,0 +1,168 @@
+// This example demonstrates how to use the colors.BlendLinear1D function to create
+// beautiful color gradients in a Bubble Tea application.
+package main
+
+import (
+	"fmt"
+	"image/color"
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/lipgloss/v2/colors"
+)
+
+var gradients = []gradientData{
+	{
+		name: "Sunset",
+		stops: []color.Color{
+			lipgloss.Color("#FF6B6B"), // Coral
+			lipgloss.Color("#FFB74D"), // Orange
+			lipgloss.Color("#FFDFBA"), // Peach
+		},
+	},
+	{
+		name: "Ocean",
+		stops: []color.Color{
+			lipgloss.Color("#0077B6"), // Deep Blue
+			lipgloss.Color("#48CAE4"), // Sky Blue
+			lipgloss.Color("#ADE8F4"), // Light Blue
+		},
+	},
+	{
+		name: "Forest",
+		stops: []color.Color{
+			lipgloss.Color("#228B22"), // Forest Green
+			lipgloss.Color("#90EE90"), // Light Green
+			lipgloss.Color("#FFFFE0"), // Cream
+		},
+	},
+	{
+		name: "Purple Dream",
+		stops: []color.Color{
+			lipgloss.Color("#9370DB"), // Medium Purple
+			lipgloss.Color("#DDA0DD"), // Plum
+			lipgloss.Color("#FFB6C1"), // Light Pink
+		},
+	},
+	{
+		name: "Fire",
+		stops: []color.Color{
+			lipgloss.Color("#FF0000"), // Red
+			lipgloss.Color("#FFA500"), // Orange
+			lipgloss.Color("#FFFF00"), // Yellow
+		},
+	},
+}
+
+type gradientData struct {
+	name  string
+	stops []color.Color
+}
+
+// Style definitions.
+type styles struct {
+	// UI styles.
+	title        lipgloss.Style
+	gradientName lipgloss.Style
+	info         lipgloss.Style
+}
+
+func newStyles(dark bool) (s *styles) {
+	s = &styles{}
+
+	lightDark := lipgloss.LightDark(dark)
+
+	s.title = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lightDark(lipgloss.Color("#2D3748"), lipgloss.Color("#E2E8F0"))).
+		MarginBottom(1).
+		Align(lipgloss.Center)
+
+	s.gradientName = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lightDark(lipgloss.Color("#4A5568"), lipgloss.Color("#CBD5E0"))).
+		PaddingRight(1)
+
+	s.info = lipgloss.NewStyle().
+		Foreground(lightDark(lipgloss.Color("#718096"), lipgloss.Color("#A0AEC0"))).
+		Italic(true)
+
+	return s
+}
+
+type model struct {
+	width  int
+	height int
+	styles *styles
+}
+
+func (m model) Init() tea.Cmd {
+	return tea.RequestBackgroundColor
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	case tea.BackgroundColorMsg:
+		m.styles = newStyles(msg.IsDark())
+		return m, nil
+
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "q", "esc", "ctrl+c":
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m model) View() (string, *tea.Cursor) {
+	var maxTitleWidth int
+
+	for _, gradient := range gradients {
+		maxTitleWidth = max(maxTitleWidth, lipgloss.Width(m.styles.gradientName.Render(gradient.name)))
+	}
+
+	var content strings.Builder
+
+	content.WriteString(m.styles.title.Render("Color Gradient Examples with BlendLinear1D"))
+	content.WriteString("\n\n")
+
+	var title string
+
+	for _, gradient := range gradients {
+		title = m.styles.gradientName.Width(maxTitleWidth).Render(gradient.name)
+		content.WriteString(title)
+
+		blendedColors := colors.BlendLinear1D(m.width-maxTitleWidth, gradient.stops...)
+
+		for _, c := range blendedColors {
+			content.WriteString(lipgloss.NewStyle().Background(c).Foreground(c).Render("█"))
+		}
+
+		content.WriteString("\n")
+	}
+
+	content.WriteString("\n")
+	content.WriteString(m.styles.info.Render("Press Q to exit"))
+
+	cursor := &tea.Cursor{}
+	cursor.X = 0
+	cursor.Y = 0
+
+	return content.String(), cursor
+}
+
+func main() {
+	_, err := tea.NewProgram(model{styles: newStyles(true)}, tea.WithAltScreen()).Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Uh oh: %v", err)
+		os.Exit(1)
+	}
+}

--- a/examples/blending/linear-1d/standalone/main.go
+++ b/examples/blending/linear-1d/standalone/main.go
@@ -1,0 +1,76 @@
+// This example demonstrates how to use the colors.BlendLinear1D function to create
+// beautiful color gradients in a standalone Lip Gloss application.
+package main
+
+import (
+	"image/color"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/lipgloss/v2/colors"
+)
+
+var gradients = [][]color.Color{
+	{
+		lipgloss.Color("#FF6B6B"), // Coral
+		lipgloss.Color("#FFB74D"), // Orange
+		lipgloss.Color("#FFDFBA"), // Peach
+	},
+	{
+		lipgloss.Color("#0077B6"), // Deep Blue
+		lipgloss.Color("#48CAE4"), // Sky Blue
+		lipgloss.Color("#ADE8F4"), // Light Blue
+	},
+	{
+		lipgloss.Color("#228B22"), // Forest Green
+		lipgloss.Color("#90EE90"), // Light Green
+		lipgloss.Color("#FFFFE0"), // Cream
+	},
+	{
+		lipgloss.Color("#9370DB"), // Medium Purple
+		lipgloss.Color("#DDA0DD"), // Plum
+		lipgloss.Color("#FFB6C1"), // Light Pink
+	},
+	{
+		lipgloss.Color("#9900FF"), // Purple
+		lipgloss.Color("#00FA68"), // Lime
+		lipgloss.Color("#ED5353"), // Red
+	},
+}
+
+func main() {
+	hasDarkBG := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	lightDark := lipgloss.LightDark(hasDarkBG)
+
+	// Create styles.
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lightDark(lipgloss.Color("#2D3748"), lipgloss.Color("#E2E8F0"))).
+		MarginBottom(1).
+		Align(lipgloss.Center)
+
+	gradientStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lightDark(lipgloss.Color("#718096"), lipgloss.Color("#A0AEC0")))
+
+	var content strings.Builder
+
+	content.WriteString(titleStyle.Render("Color Gradient Examples with BlendLinear1D"))
+	content.WriteString("\n")
+
+	for _, gradient := range gradients {
+		blendedColors := colors.BlendLinear1D(40, gradient...)
+
+		var gradientBar strings.Builder
+		for _, c := range blendedColors {
+			blockStyle := lipgloss.NewStyle().Foreground(c)
+			gradientBar.WriteString(blockStyle.Render("█"))
+		}
+
+		content.WriteString(gradientStyle.Render(gradientBar.String()))
+		content.WriteString("\n")
+	}
+
+	lipgloss.Println(content.String())
+}

--- a/examples/blending/linear-2d/bubbletea/main.go
+++ b/examples/blending/linear-2d/bubbletea/main.go
@@ -1,0 +1,183 @@
+// This example demonstrates how to use the colors.BlendLinear2D function to create
+// beautiful 2D color gradients in a Bubble Tea application.
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"image/color"
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/lipgloss/v2/colors"
+)
+
+var gradients = [][]color.Color{
+	{
+		lipgloss.Color("#FF6B6B"), // Coral
+		lipgloss.Color("#FFB74D"), // Orange
+		lipgloss.Color("#FFDFBA"), // Peach
+	},
+	{
+		lipgloss.Color("#0077B6"), // Deep Blue
+		lipgloss.Color("#48CAE4"), // Sky Blue
+		lipgloss.Color("#ADE8F4"), // Light Blue
+	},
+	{
+		lipgloss.Color("#228B22"), // Forest Green
+		lipgloss.Color("#90EE90"), // Light Green
+		lipgloss.Color("#FFFFE0"), // Cream
+	},
+	{
+		lipgloss.Color("#9370DB"), // Medium Purple
+		lipgloss.Color("#DDA0DD"), // Plum
+		lipgloss.Color("#FFB6C1"), // Light Pink
+	},
+	{
+		lipgloss.Color("#9900FF"), // Purple
+		lipgloss.Color("#00FA68"), // Lime
+		lipgloss.Color("#ED5353"), // Red
+	},
+}
+
+func main() {
+	m := model{
+		boxWidth:         20,
+		boxHeight:        10,
+		angle:            45,
+		selectedGradient: 0,
+
+		infoStyle: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#888888")).
+			MarginTop(1),
+		controlsStyle: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#666666")).
+			MarginTop(1),
+		gradientBoxStyle: lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#666666")),
+	}
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	if _, err := p.Run(); err != nil {
+		fmt.Printf("Alas, there's been an error: %v", err)
+		os.Exit(1)
+	}
+}
+
+type model struct {
+	// UI state.
+	windowWidth      int
+	windowHeight     int
+	boxWidth         int
+	boxHeight        int
+	angle            int
+	selectedGradient int
+
+	// UI styles.
+	infoStyle        lipgloss.Style
+	controlsStyle    lipgloss.Style
+	gradientBoxStyle lipgloss.Style
+}
+
+func (m model) Init() tea.Cmd {
+	return nil
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.windowWidth = msg.Width
+		m.windowHeight = msg.Height
+		m.calcBoxSize()
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c", "esc":
+			return m, tea.Quit
+		case "a":
+			m.angle = (m.angle + 15) % 360
+		case "d":
+			m.angle = (m.angle - 15 + 360) % 360
+		case "left":
+			m.boxWidth -= 2
+			m.calcBoxSize()
+		case "right":
+			m.boxWidth += 2
+			m.calcBoxSize()
+		case "up":
+			m.boxHeight--
+			m.calcBoxSize()
+		case "down":
+			m.boxHeight++
+			m.calcBoxSize()
+		case "1", "2", "3", "4", "5", "6", "7", "8", "9":
+			m.selectedGradient = max(0, min(int(msg.String()[0]-'1'), len(gradients)-1))
+		}
+	case tea.MouseClickMsg:
+		switch msg.Mouse().Button {
+		case tea.MouseLeft:
+			m.boxWidth = msg.Mouse().X
+			m.boxHeight = msg.Mouse().Y
+			m.calcBoxSize()
+		}
+	}
+	return m, nil
+}
+
+func (m *model) calcBoxSize() {
+	m.boxWidth = clamp(m.boxWidth, 5, m.windowWidth-m.gradientBoxStyle.GetHorizontalFrameSize())
+	m.boxHeight = clamp(m.boxHeight, 3, m.windowHeight-m.gradientBoxStyle.GetVerticalFrameSize()-m.infoStyle.GetVerticalFrameSize()-m.controlsStyle.GetVerticalFrameSize()-2)
+}
+
+func (m model) View() string {
+	gradientColors := colors.BlendLinear2D(m.boxWidth, m.boxHeight, m.angle, gradients[m.selectedGradient]...)
+
+	// Build the gradient content.
+	gradientContent := strings.Builder{}
+	for y := range m.boxHeight {
+		for x := range m.boxWidth {
+			index := y*m.boxWidth + x
+			gradientContent.WriteString(
+				lipgloss.NewStyle().
+					Background(gradientColors[index]).
+					Render(" "),
+			)
+		}
+		if y < m.boxHeight-1 { // End of row.
+			gradientContent.WriteString("\n")
+		}
+	}
+
+	gradient := m.gradientBoxStyle.Render(gradientContent.String())
+
+	info := m.infoStyle.Width(m.windowWidth).Render(fmt.Sprintf(
+		"Size: %dx%d | Angle: %d° | Colors: %d",
+		m.boxWidth,
+		m.boxHeight,
+		m.angle,
+		len(gradients[m.selectedGradient]),
+	))
+
+	controls := m.controlsStyle.Width(m.windowWidth).Render(fmt.Sprintf(
+		"Controls: a/d (angle) | ←→ (width) | ↑↓ (height) | 1-%d (color scheme) | mouse click",
+		len(gradients),
+	))
+
+	return lipgloss.NewStyle().
+		Width(m.windowWidth).
+		Height(m.windowHeight).
+		Render(lipgloss.JoinVertical(
+			lipgloss.Top,
+			lipgloss.NewStyle().
+				Width(m.windowWidth).
+				Height(m.windowHeight-lipgloss.Height(info)-lipgloss.Height(controls)).
+				Render(gradient),
+			info,
+			controls,
+		))
+}
+
+func clamp[T cmp.Ordered](v, low, high T) T {
+	return min(high, max(low, v))
+}

--- a/examples/blending/linear-2d/bubbletea/main.go
+++ b/examples/blending/linear-2d/bubbletea/main.go
@@ -98,8 +98,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "a":
 			m.angle = (m.angle + 15) % 360
+			m.updateGradient()
 		case "d":
 			m.angle = (m.angle - 15 + 360) % 360
+			m.updateGradient()
 		case "left":
 			m.boxWidth -= 2
 			m.updateGradient()
@@ -114,6 +116,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateGradient()
 		case "1", "2", "3", "4", "5", "6", "7", "8", "9":
 			m.selectedGradient = max(0, min(int(msg.String()[0]-'1'), len(gradients)-1))
+			m.updateGradient()
 		}
 	case tea.MouseClickMsg:
 		switch msg.Mouse().Button {

--- a/examples/blending/linear-2d/standalone/main.go
+++ b/examples/blending/linear-2d/standalone/main.go
@@ -1,0 +1,121 @@
+// This example demonstrates how to use the colors.BlendLinear2D function to create
+// beautiful 2D color gradients in a standalone Lip Gloss application.
+package main
+
+import (
+	"fmt"
+	"image/color"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/lipgloss/v2/colors"
+)
+
+func main() {
+	hasDarkBG := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	lightDark := lipgloss.LightDark(hasDarkBG)
+
+	gradients := []struct {
+		name  string
+		stops []color.Color
+		angle int
+	}{
+		{
+			name: "Sunset Diagonal",
+			stops: []color.Color{
+				lipgloss.Color("#FF6B6B"), // Coral
+				lipgloss.Color("#FFB74D"), // Orange
+				lipgloss.Color("#FFDFBA"), // Peach
+			},
+			angle: 45,
+		},
+		{
+			name: "Ocean Wave",
+			stops: []color.Color{
+				lipgloss.Color("#0077B6"), // Deep Blue
+				lipgloss.Color("#48CAE4"), // Sky Blue
+				lipgloss.Color("#ADE8F4"), // Light Blue
+			},
+			angle: 90,
+		},
+		{
+			name: "Forest Mist",
+			stops: []color.Color{
+				lipgloss.Color("#228B22"), // Forest Green
+				lipgloss.Color("#90EE90"), // Light Green
+				lipgloss.Color("#FFFFE0"), // Cream
+			},
+			angle: 135,
+		},
+		{
+			name: "Purple Dream",
+			stops: []color.Color{
+				lipgloss.Color("#9370DB"), // Medium Purple
+				lipgloss.Color("#DDA0DD"), // Plum
+				lipgloss.Color("#FFB6C1"), // Light Pink
+			},
+			angle: 180,
+		},
+		{
+			name: "Fire Gradient",
+			stops: []color.Color{
+				lipgloss.Color("#FF0000"), // Red
+				lipgloss.Color("#FFA500"), // Orange
+				lipgloss.Color("#FFFF00"), // Yellow
+			},
+			angle: 225,
+		},
+	}
+
+	// Create styles.
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lightDark(lipgloss.Color("#2D3748"), lipgloss.Color("#E2E8F0"))).
+		MarginBottom(1).
+		Align(lipgloss.Center)
+
+	gradientStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lightDark(lipgloss.Color("#718096"), lipgloss.Color("#A0AEC0"))).
+		MarginBottom(1)
+
+	gradientNameStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lightDark(lipgloss.Color("#4A5568"), lipgloss.Color("#CBD5E0"))).
+		MarginBottom(1)
+
+	var content strings.Builder
+
+	content.WriteString(titleStyle.Render("2D Color Gradient Examples with BlendLinear2D"))
+	content.WriteString("\n\n")
+
+	for _, gradient := range gradients {
+		// Generate the gradient using BlendLinear2D.
+		width, height := 30, 12
+		blendedColors := colors.BlendLinear2D(width, height, gradient.angle, gradient.stops...)
+
+		// Create the gradient box using individual character styling.
+		var gradientBox strings.Builder
+		for y := range height {
+			for x := range width {
+				index := y*width + x
+				gradientBox.WriteString(
+					lipgloss.NewStyle().
+						Foreground(blendedColors[index]).
+						Render("█"),
+				)
+			}
+			if y < height-1 { // End of row.
+				gradientBox.WriteString("\n")
+			}
+		}
+
+		content.WriteString(gradientNameStyle.Render(fmt.Sprintf("%s (Angle: %d°)", gradient.name, gradient.angle)))
+		content.WriteString("\n")
+		content.WriteString(gradientStyle.Render(gradientBox.String()))
+		content.WriteString("\n")
+	}
+
+	lipgloss.Println(content.String())
+}

--- a/examples/blending/linear-2d/standalone/main.go
+++ b/examples/blending/linear-2d/standalone/main.go
@@ -97,7 +97,7 @@ func main() {
 
 		// Create the gradient box using individual character styling.
 		var gradientBox strings.Builder
-		for y := range height {
+		for y := range height { // Uses 1D row-major order.
 			for x := range width {
 				index := y*width + x
 				gradientBox.WriteString(

--- a/examples/brightness/main.go
+++ b/examples/brightness/main.go
@@ -1,0 +1,70 @@
+// This example demonstrates how to use the colors.Lighten and colors.Darken functions
+// to create progressive brightness variations in a standalone Lip Gloss application.
+package main
+
+import (
+	"image/color"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/lipgloss/v2/colors"
+)
+
+func main() {
+	hasDarkBG := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	lightDark := lipgloss.LightDark(hasDarkBG)
+
+	// Base colors to demonstrate lightening and darkening.
+	baseColors := map[string]color.Color{
+		"Red":   lipgloss.Color("#FF0000"),
+		"Blue":  lipgloss.Color("#0066FF"),
+		"Green": lipgloss.Color("#00FF00"),
+		"Gray":  lipgloss.Color("#808080"),
+	}
+
+	// Percentage to lighten/darken by.
+	percentage := 5 // 5%
+
+	// Number of steps to generate.
+	steps := 20
+
+	colorNameStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lightDark(lipgloss.Color("#2D3748"), lipgloss.Color("#E2E8F0")))
+
+	var content strings.Builder
+
+	for name, baseColor := range baseColors {
+		content.WriteString(colorNameStyle.Render(name))
+		content.WriteString("\n")
+
+		// Create lightened variations.
+		var lightenedBox strings.Builder
+		lightenedBox.WriteString("Lightened: ")
+		for i := range steps {
+			lightenedBox.WriteString(
+				lipgloss.NewStyle().
+					Foreground(colors.Lighten(baseColor, percentage*(i+1))).
+					Render("██"),
+			)
+		}
+		content.WriteString(lightenedBox.String())
+		content.WriteString("\n")
+
+		// Create darkened variations.
+		var darkenedBox strings.Builder
+		darkenedBox.WriteString("Darkened:  ")
+		for i := range steps {
+			darkenedBox.WriteString(
+				lipgloss.NewStyle().
+					Foreground(colors.Darken(baseColor, percentage*(i+1))).
+					Render("██"),
+			)
+		}
+		content.WriteString(darkenedBox.String())
+		content.WriteString("\n\n")
+	}
+
+	lipgloss.Println(content.String())
+}


### PR DESCRIPTION
## Describe your changes

- Initial implementation of sub-package `colors`, which provides helpers for mutating colors, as well as adding color blending/gradient functionality, including:
  - `BlendLinear1D` - 1-dimensional linear blending between 2+ color stops across `N` number of steps.
    - Has examples.
  - `BlendLinear2D` - 2-dimensional linear blending between 2+ color stops across `N` number of steps, with an angle to control direction (e.g. diagonal).
    - Has examples.
  - `Lighten` - increase the brightness of a color.
    - Has examples (lighten/darken in 1).
  - `Darken` - decrease the brightness of a color.
    - Has examples (lighten/darken in 1).
  - `Alpha` - simple helper for adjusting the alpha value of a color.
  - `Complementary` - get the complementary color of a given color.

If this is merged, this will also render the following no longer necessary:

- `github.com/charmbracelet/x/exp/color`
- `github.com/charmbracelet/x/exp/charmtone#Blend`

## Screenshots & Examples

<details>
<summary>All screenshots & videos</summary>

Video is a bit compressed, but:

https://github.com/user-attachments/assets/3f6d7263-16f0-44b1-8ef8-32914ab8d4f2

<img width="377" height="420" alt="image" src="https://github.com/user-attachments/assets/04bcbdb1-7139-4379-bd6d-7d3404f0501c" />

<img width="476" height="447" alt="image" src="https://github.com/user-attachments/assets/a3a41e52-bb1a-48d6-a292-43a56f7be315" />

<img width="572" height="405" alt="image" src="https://github.com/user-attachments/assets/3cafb370-8091-4a7f-8f4d-571d6286b23f" />

</details>

## Related issue/discussion:

- ref: https://github.com/charmbracelet/lipgloss/pull/154#issuecomment-2738045085
- ref: https://github.com/charmbracelet/lipgloss/discussions/50

## Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

## If this is a feature

- [x] I have created a discussion (n/a: discussed with @meowgorithm)
  - Discussed in Discord with Christian. tl;dr: I don't think the charm team originally wanted blend functionality grouped in with lipgloss (re: [154](https://github.com/charmbracelet/lipgloss/pull/154#issuecomment-2738045085) & [50](https://github.com/charmbracelet/lipgloss/discussions/50), however, the usage of blending continues to grow in the bubbletea/lipgloss ecosystem, and there is now interest in including this in lipgloss directly for simplicity.
- [x] A project maintainer has approved this feature request.

## Notes for Reviewer

### HCL vs LAB

The `Blend*` functionality uses `BlendLab` rather than `BlendHcl` (what `github.com/charmbracelet/x/exp/color` and crush use). For both 1D and 2D implementations, when using HCL, I noticed that despite proper input into the `BlendHcl` method, for some colors, it produced output which did not gracefully blend multiple colors (one color standing out drastically from others, see below screenshot and example). In addition, it would often cut off a good portion of the start and end colors as part of gradient generation. Using LAB, it's much more consistent and doesn't seem to suffer from the issues with the `BlendHcl` implementation.

<details>
<summary>Color blend bug with BlendHcl</summary>

<img width="805" height="420" alt="image" src="https://github.com/user-attachments/assets/7a74ef7f-de56-47e4-8ca3-960243726f40" />
</details>

To replicate this issue, switch `BlendLab` with `BlendHcl`, and use this repro:

<details>
<summary>BlendHcl reproduction code</summary>

```go
package main

import (
	"image/color"
	"strings"

	"github.com/charmbracelet/lipgloss/v2"
	"github.com/charmbracelet/lipgloss/v2/colors"
)

func main() {
	height := 15
	width := 65
	angle := 0

	blendedColors := colors.BlendLinear2D(
		width,
		height,
		angle,
		color.RGBA{R: 0, G: 119, B: 182, A: 255},
		color.RGBA{R: 72, G: 202, B: 228, A: 255},
		color.RGBA{R: 173, G: 232, B: 244, A: 255},
	)

	var s strings.Builder
	for y := range height {
		for x := range width {
			index := y*width + x
			blockStyle := lipgloss.NewStyle().Foreground(blendedColors[index])
			s.WriteString(blockStyle.Render("█"))
		}
		if y < height-1 {
			s.WriteString("\n")
		}
	}

	lipgloss.Println(s.String())
}
```

</details>

### Usage of 1D return array for `BlendLinear2D`

With the current implementation of `BlendLinear2D`, I return a 1D array in row-major order. This is primarily due to performance; however, it does feel a little more annoying to use:

<details>
<summary>1D row-major order loop pseudo-code</summary>

```go
gradient := colors.BlendLinear2D(width, height, 180, color1, color2, color3, ...)
gradientContent := strings.Builder{}
for y := range height {
	for x := range width {
		index := y*width + x
		gradientContent.WriteString(
			lipgloss.NewStyle().
				Background(gradient[index]).
				Render(" "),
		)
	}
	if y < height-1 { // End of row.
		gradientContent.WriteString("\n")
	}
}
```

</details>

I benchmarked returning a 2D array, which would be simpler to iterate over, however, results in about **49% more** allocations and **10% more** memory usage for a 100x100 test case. 100x100 is of course probably a much higher amount than someone would actually use, however, even for the examples I've provided, gradient generation (although I think as simple as it can be as far as allocations), still does use a good amount of memory _if you're not caching the gradient in your model -- e.g. dynamic usecases_.

<details>
<summary>2D row-major order loop pseudo-code</summary>

```go
gradient := colors.BlendLinear2D(width, height, 180, color1, color2, color3, ...)
gradientContent := strings.Builder{}

for y := range height {
	for x := range width {
		gradientContent.WriteString(
			lipgloss.NewStyle().
				Background(gradient2D[y][x]).
				Render(" "),
		)
	}
	if y < height-1 { // End of row.
		gradientContent.WriteString("\n")
	}
}
```

</details>

Thoughts? IMO, the former isn't that bad, so I don't think it's worth the extra resource overhead.

### To panic or not to panic

There is a handful of logic, specifically in the `Blend*` methods, around using various fallbacks if the user of the library provides potentially invalid data. Some examples:

- If some of the colors are invalid (e.g. nil), remove them from the color stops.
- If they provide a valid and invalid color, duplicate the valid color, so it won't be a gradient, but at least it won't panic.
- If `steps < 2`, always just output 2 steps, so in most cases, their `0` index will work, even if it isn't a gradient.

Typically, most of the lipgloss stuff doesn't return an error, which I suspect is because it's commonly used in `View()` methods which aren't supposed to produce actual logic, so returning an error probably doesn't make sense here. But what about panics for invalid input data? Fallback, or panic?