### PR TITLE
feat(borders): initial border blend implementation

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -2,6 +2,7 @@ package lipgloss
 
 import (
 	"image/color"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
@@ -278,6 +279,59 @@ func ASCIIBorder() Border {
 	return asciiBorder
 }
 
+type borderBlend struct {
+	topGradient    []color.Color
+	rightGradient  []color.Color
+	bottomGradient []color.Color
+	leftGradient   []color.Color
+}
+
+func (s Style) borderBlend(width, height int, colors ...color.Color) *borderBlend {
+	var gradient []color.Color
+
+	if s.getAsBool(borderBlendWrapKey, false) {
+		gradient = Blend1D(
+			// half of total number of border chars. +2 for max potential corner char
+			// size. Currently, corners are limited to 1 rune each.
+			height+width+2,
+			colors...,
+		)
+
+		// Duplicate the gradient (which is half size), and add it to the end of the
+		// gradient in reverse. This allows us to seamlessly blend. E.g. if you just
+		// did A->B->C, C wouldn't blend with A when at the end of the gradient. So
+		// do A->B->C->C->B->A. It's not perfect, because there are larger consecutive
+		// sections of A and C, but looks "good enough".
+		gradient = append(gradient, slices.Clone(gradient)...)
+		slices.Reverse(gradient[height+width+2:])
+	} else {
+		gradient = Blend1D(
+			(height+width+2)*2,
+			colors...,
+		)
+	}
+
+	blend := &borderBlend{}
+
+	offset := 0
+	getFromOffset := func(size int) (s []color.Color) {
+		s = gradient[offset : offset+size]
+		offset += size
+		return s
+	}
+
+	blend.topGradient = getFromOffset(width + 2)
+	blend.rightGradient = getFromOffset(height)
+	blend.bottomGradient = getFromOffset(width + 2)
+	blend.leftGradient = getFromOffset(height)
+
+	// bottom and left gradients are reversed because they are drawn in reverse order.
+	slices.Reverse(blend.bottomGradient)
+	slices.Reverse(blend.leftGradient)
+
+	return blend
+}
+
 func (s Style) applyBorder(str string) string {
 	var (
 		border    = s.getBorderStyle()
@@ -285,16 +339,6 @@ func (s Style) applyBorder(str string) string {
 		hasRight  = s.getAsBool(borderRightKey, false)
 		hasBottom = s.getAsBool(borderBottomKey, false)
 		hasLeft   = s.getAsBool(borderLeftKey, false)
-
-		topFG    = s.getAsColor(borderTopForegroundKey)
-		rightFG  = s.getAsColor(borderRightForegroundKey)
-		bottomFG = s.getAsColor(borderBottomForegroundKey)
-		leftFG   = s.getAsColor(borderLeftForegroundKey)
-
-		topBG    = s.getAsColor(borderTopBackgroundKey)
-		rightBG  = s.getAsColor(borderRightBackgroundKey)
-		bottomBG = s.getAsColor(borderBottomBackgroundKey)
-		leftBG   = s.getAsColor(borderLeftBackgroundKey)
 	)
 
 	// If a border is set and no sides have been specifically turned on or off
@@ -320,8 +364,11 @@ func (s Style) applyBorder(str string) string {
 		width += maxRuneWidth(border.Left)
 	}
 
-	if hasRight && border.Right == "" {
-		border.Right = " "
+	if hasRight {
+		if border.Right == "" {
+			border.Right = " "
+		}
+		width += maxRuneWidth(border.Right)
 	}
 
 	// If corners should be rendered but are set with the empty string, fill them
@@ -370,13 +417,35 @@ func (s Style) applyBorder(str string) string {
 	border.BottomRight = getFirstRuneAsString(border.BottomRight)
 	border.BottomLeft = getFirstRuneAsString(border.BottomLeft)
 
+	var topFG, rightFG, bottomFG, leftFG color.Color
+	var (
+		blendFG  = s.getAsColors(borderBlendForegroundKey)
+		topBG    = s.getAsColor(borderTopBackgroundKey)
+		rightBG  = s.getAsColor(borderRightBackgroundKey)
+		bottomBG = s.getAsColor(borderBottomBackgroundKey)
+		leftBG   = s.getAsColor(borderLeftBackgroundKey)
+	)
+
+	var blend *borderBlend
+	if len(blendFG) > 0 {
+		blend = s.borderBlend(width, len(lines), blendFG...)
+	} else {
+		topFG = s.getAsColor(borderTopForegroundKey)
+		rightFG = s.getAsColor(borderRightForegroundKey)
+		bottomFG = s.getAsColor(borderBottomForegroundKey)
+		leftFG = s.getAsColor(borderLeftForegroundKey)
+	}
+
 	var out strings.Builder
 
 	// Render top
 	if hasTop {
 		top := renderHorizontalEdge(border.TopLeft, border.Top, border.TopRight, width)
-		top = s.styleBorder(top, topFG, topBG)
-		out.WriteString(top)
+		if blend != nil {
+			out.WriteString(s.styleBorderBlend(top, blend.topGradient, topBG))
+		} else {
+			out.WriteString(s.styleBorder(top, topFG, topBG))
+		}
 		out.WriteRune('\n')
 	}
 
@@ -387,23 +456,32 @@ func (s Style) applyBorder(str string) string {
 	rightIndex := 0
 
 	// Render sides
+	var r string
 	for i, l := range lines {
 		if hasLeft {
-			r := string(leftRunes[leftIndex])
+			r = string(leftRunes[leftIndex])
 			leftIndex++
 			if leftIndex >= len(leftRunes) {
 				leftIndex = 0
 			}
-			out.WriteString(s.styleBorder(r, leftFG, leftBG))
+			if blend != nil {
+				out.WriteString(s.styleBorder(r, blend.leftGradient[i], leftBG))
+			} else {
+				out.WriteString(s.styleBorder(r, leftFG, leftBG))
+			}
 		}
 		out.WriteString(l)
 		if hasRight {
-			r := string(rightRunes[rightIndex])
+			r = string(rightRunes[rightIndex])
 			rightIndex++
 			if rightIndex >= len(rightRunes) {
 				rightIndex = 0
 			}
-			out.WriteString(s.styleBorder(r, rightFG, rightBG))
+			if blend != nil {
+				out.WriteString(s.styleBorder(r, blend.rightGradient[i], rightBG))
+			} else {
+				out.WriteString(s.styleBorder(r, rightFG, rightBG))
+			}
 		}
 		if i < len(lines)-1 {
 			out.WriteRune('\n')
@@ -413,9 +491,12 @@ func (s Style) applyBorder(str string) string {
 	// Render bottom
 	if hasBottom {
 		bottom := renderHorizontalEdge(border.BottomLeft, border.Bottom, border.BottomRight, width)
-		bottom = s.styleBorder(bottom, bottomFG, bottomBG)
 		out.WriteRune('\n')
-		out.WriteString(bottom)
+		if blend != nil {
+			out.WriteString(s.styleBorderBlend(bottom, blend.bottomGradient, bottomBG))
+		} else {
+			out.WriteString(s.styleBorder(bottom, bottomFG, bottomBG))
+		}
 	}
 
 	return out.String()
@@ -435,25 +516,26 @@ func renderHorizontalEdge(left, middle, right string, width int) string {
 
 	out := strings.Builder{}
 	out.WriteString(left)
-	for i := leftWidth + rightWidth; i < width+rightWidth; {
-		out.WriteRune(runes[j])
+
+	for i := 0; i < width-leftWidth-rightWidth; {
+		r := runes[j]
+		out.WriteRune(r)
+		i += ansi.StringWidth(string(r))
 		j++
 		if j >= len(runes) {
 			j = 0
 		}
-		i += ansi.StringWidth(string(runes[j]))
 	}
-	out.WriteString(right)
 
+	out.WriteString(right)
 	return out.String()
 }
 
-// Apply foreground and background styling to a border.
+// styleBorder applies foreground and background styling to a border.
 func (s Style) styleBorder(border string, fg, bg color.Color) string {
 	if fg == noColor && bg == noColor {
 		return border
 	}
-
 	var style ansi.Style
 	if fg != noColor {
 		style = style.ForegroundColor(fg)
@@ -461,8 +543,30 @@ func (s Style) styleBorder(border string, fg, bg color.Color) string {
 	if bg != noColor {
 		style = style.BackgroundColor(bg)
 	}
-
 	return style.Styled(border)
+}
+
+// styleBorderBlend applies foreground and background styling to a border, using blending.
+func (s Style) styleBorderBlend(border string, fg []color.Color, bg color.Color) string {
+	var out strings.Builder
+	var style ansi.Style
+	var i int
+
+	gr := uniseg.NewGraphemes(border)
+	for gr.Next() {
+		style = style[:0]
+		if fg[i] != noColor {
+			style = style.ForegroundColor(fg[i])
+		}
+		if bg != noColor {
+			style = style.BackgroundColor(bg)
+		}
+		_, _ = out.WriteString(style.String())
+		_, _ = out.Write(gr.Bytes())
+		i++
+	}
+	_, _ = out.WriteString(ansi.ResetStyle)
+	return out.String()
 }
 
 func maxRuneWidth(str string) int {

--- a/borders_test.go
+++ b/borders_test.go
@@ -1,0 +1,95 @@
+package lipgloss
+
+import (
+	"testing"
+)
+
+func BenchmarkBorderRendering(b *testing.B) {
+	dimensions := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"10x5", 10, 5},
+		{"20x10", 20, 10},
+		{"40x20", 40, 15},
+		{"80x40", 80, 20},
+		{"120x60", 120, 25},
+		{"160x80", 160, 30},
+	}
+
+	for _, dim := range dimensions {
+		b.Run(dim.name, func(b *testing.B) {
+			style := NewStyle().
+				Border(RoundedBorder(), true).
+				Foreground(Color("#ffffff")).
+				Background(Color("#000000")).
+				Width(dim.width).
+				Height(dim.height)
+
+			b.ResetTimer()
+			for b.Loop() {
+				_ = style.Render("")
+			}
+		})
+	}
+}
+
+func BenchmarkBorderBlend(b *testing.B) {
+	dimensions := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"10x5", 10, 5},
+		{"20x10", 20, 10},
+		{"40x20", 40, 15},
+		{"80x40", 80, 20},
+		{"120x60", 120, 25},
+		{"160x80", 160, 30},
+	}
+
+	for _, dim := range dimensions {
+		b.Run(dim.name, func(b *testing.B) {
+			style := NewStyle().
+				Border(RoundedBorder(), true).
+				BorderBlendForeground(Color("#00FA68"), Color("#9900FF"), Color("#ED5353")).
+				Width(dim.width).
+				Height(dim.height)
+
+			b.ResetTimer()
+			for b.Loop() {
+				_ = style.Render("")
+			}
+		})
+	}
+}
+
+func BenchmarkBorderRenderingNoColors(b *testing.B) {
+	dimensions := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"10x5", 10, 5},
+		{"20x10", 20, 10},
+		{"40x20", 40, 15},
+		{"80x40", 80, 20},
+		{"120x60", 120, 25},
+		{"160x80", 160, 30},
+	}
+
+	for _, dim := range dimensions {
+		b.Run(dim.name, func(b *testing.B) {
+			style := NewStyle().
+				Border(RoundedBorder(), true).
+				Width(dim.width).
+				Height(dim.height)
+
+			b.ResetTimer()
+			for b.Loop() {
+				_ = style.Render("")
+			}
+		})
+	}
+}

--- a/examples/blending/linear-2d/bubbletea/main.go
+++ b/examples/blending/linear-2d/bubbletea/main.go
@@ -57,7 +57,12 @@ func main() {
 			MarginTop(1),
 		gradientBoxStyle: lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#666666")),
+			BorderBlendForeground(
+				lipgloss.Color("#00FA68"),
+				lipgloss.Color("#9900FF"),
+				lipgloss.Color("#ED5353"),
+			).
+			BorderBlendWrap(true),
 	}
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {

--- a/examples/canvas/main.go
+++ b/examples/canvas/main.go
@@ -30,7 +30,13 @@ func newCard(darkMode bool, text string) string {
 
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(charmtone.Charple).
+		BorderBlendForeground(
+			charmtone.Cherry,
+			charmtone.Charple,
+			charmtone.Guac,
+			charmtone.Charple,
+			charmtone.Sriracha,
+		).
 		Foreground(lightDark(charmtone.Iron, charmtone.Butter)).
 		Height(9).
 		Width(16).

--- a/get.go
+++ b/get.go
@@ -284,6 +284,18 @@ func (s Style) GetBorderLeftForeground() color.Color {
 	return s.getAsColor(borderLeftForegroundKey)
 }
 
+// GetBorderBlendForeground returns the style's border blend foreground colors.
+// If no value is set, nil is returned.
+func (s Style) GetBorderBlendForeground() []color.Color {
+	return s.getAsColors(borderBlendForegroundKey)
+}
+
+// GetBorderBlendWrap returns the style's border blend wrap setting. If no value
+// is set, false is returned.
+func (s Style) GetBorderBlendWrap() bool {
+	return s.getAsBool(borderBlendWrapKey, false)
+}
+
 // GetBorderTopBackground returns the style's border top background color. If
 // no value is set NoColor{} is returned.
 func (s Style) GetBorderTopBackground() color.Color {
@@ -470,6 +482,19 @@ func (s Style) getAsBool(k propKey, defaultVal bool) bool {
 		return defaultVal
 	}
 	return s.attrs&int(k) != 0
+}
+
+func (s Style) getAsColors(k propKey) (colors []color.Color) {
+	if !s.isSet(k) {
+		return nil
+	}
+
+	switch k { //nolint:exhaustive
+	case borderBlendForegroundKey:
+		return s.borderBlendFgColor
+	}
+
+	return nil
 }
 
 func (s Style) getAsColor(k propKey) color.Color {

--- a/set.go
+++ b/set.go
@@ -53,6 +53,8 @@ func (s *Style) set(key propKey, value any) {
 		s.borderBottomFgColor = colorOrNil(value)
 	case borderLeftForegroundKey:
 		s.borderLeftFgColor = colorOrNil(value)
+	case borderBlendForegroundKey:
+		s.borderBlendFgColor = value.([]color.Color)
 	case borderTopBackgroundKey:
 		s.borderTopBgColor = colorOrNil(value)
 	case borderRightBackgroundKey:
@@ -139,6 +141,8 @@ func (s *Style) setFrom(key propKey, i Style) {
 		s.set(borderBottomForegroundKey, i.borderBottomFgColor)
 	case borderLeftForegroundKey:
 		s.set(borderLeftForegroundKey, i.borderLeftFgColor)
+	case borderBlendForegroundKey:
+		s.set(borderBlendForegroundKey, i.borderBlendFgColor)
 	case borderTopBackgroundKey:
 		s.set(borderTopBackgroundKey, i.borderTopBgColor)
 	case borderRightBackgroundKey:
@@ -559,6 +563,34 @@ func (s Style) BorderBottomForeground(c color.Color) Style {
 // border.
 func (s Style) BorderLeftForeground(c color.Color) Style {
 	s.set(borderLeftForegroundKey, c)
+	return s
+}
+
+// BorderBlendForeground sets the foreground colors for the border blend. At least
+// 2 colors are required to use blending, otherwise this will no-op with 0 colors,
+// and pass to BorderForeground with 1 color. This will override all other border
+// foreground colors when used.
+func (s Style) BorderBlendForeground(c ...color.Color) Style {
+	if len(c) == 0 {
+		return s
+	}
+
+	// Insufficient colors to use blending, pass to BorderForeground.
+	if len(c) == 1 {
+		return s.BorderForeground(c...)
+	}
+
+	s.set(borderBlendForegroundKey, c)
+	return s
+}
+
+// BorderBlendWrap sets the border blend wrap setting. If true, we will take the
+// blending provided to [Style.BorderBlendForeground], use it for half of of the
+// border, then invert the gradient for the other half. Use this to create a
+// seamless blend that can wrap around the edges of the border, so the start and
+// end of the blend are the same color.
+func (s Style) BorderBlendWrap(v bool) Style {
+	s.set(borderBlendWrapKey, v)
 	return s
 }
 

--- a/size.go
+++ b/size.go
@@ -13,7 +13,7 @@ import (
 // You should use this instead of len(string) or len([]rune(string) as neither
 // will give you accurate results.
 func Width(str string) (width int) {
-	for _, l := range strings.Split(str, "\n") {
+	for l := range strings.SplitSeq(str, "\n") {
 		w := ansi.StringWidth(l)
 		if w > width {
 			width = w

--- a/size_test.go
+++ b/size_test.go
@@ -1,0 +1,41 @@
+package lipgloss
+
+import (
+	"strings"
+	"testing"
+)
+
+func BenchmarkWidthSimple(b *testing.B) {
+	simpleStrings := []string{
+		"ab",
+		"abcdef",
+		"abcdefghij",
+	}
+
+	for _, str := range simpleStrings {
+		b.Run("len-"+str, func(b *testing.B) {
+			for b.Loop() {
+				_ = Width(str)
+			}
+		})
+	}
+}
+
+func BenchmarkWidthMultiLine(b *testing.B) {
+	multiLineStrings := []struct {
+		name string
+		str  string
+	}{
+		{"2-lines", "Line 1\nLine 2"},
+		{"10-lines", "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10"},
+		{"50-lines", strings.Repeat("Line\n", 49) + "Line"},
+	}
+
+	for _, tc := range multiLineStrings {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				_ = Width(tc.str)
+			}
+		})
+	}
+}

--- a/style.go
+++ b/style.go
@@ -69,6 +69,8 @@ const (
 	borderRightForegroundKey
 	borderBottomForegroundKey
 	borderLeftForegroundKey
+	borderBlendForegroundKey
+	borderBlendWrapKey
 
 	// Border background colors.
 	borderTopBackgroundKey
@@ -145,6 +147,7 @@ type Style struct {
 	borderRightFgColor  color.Color
 	borderBottomFgColor color.Color
 	borderLeftFgColor   color.Color
+	borderBlendFgColor  []color.Color
 	borderTopBgColor    color.Color
 	borderRightBgColor  color.Color
 	borderBottomBgColor color.Color

--- a/style.go
+++ b/style.go
@@ -371,11 +371,16 @@ func (s Style) Render(strs ...string) string {
 	{
 		var b strings.Builder
 
-		l := strings.Split(str, "\n")
-		for i := range l {
+		isFirst := true
+		for line := range strings.SplitSeq(str, "\n") {
+			if isFirst {
+				isFirst = false
+			} else {
+				b.WriteRune('\n')
+			}
 			if useSpaceStyler {
 				// Look for spaces and apply a different styler
-				for _, r := range l[i] {
+				for _, r := range line {
 					if unicode.IsSpace(r) {
 						b.WriteString(teSpace.Styled(string(r)))
 						continue
@@ -383,10 +388,7 @@ func (s Style) Render(strs ...string) string {
 					b.WriteString(te.Styled(string(r)))
 				}
 			} else {
-				b.WriteString(te.Styled(l[i]))
-			}
-			if i != len(l)-1 {
-				b.WriteRune('\n')
+				b.WriteString(te.Styled(line))
 			}
 		}
 
@@ -553,22 +555,22 @@ func pad(str string, n int, style *ansi.Style, r rune) string {
 	}
 
 	b := strings.Builder{}
-	l := strings.Split(str, "\n")
-
-	for i := range l {
+	isFirst := true
+	for line := range strings.SplitSeq(str, "\n") {
+		if isFirst {
+			isFirst = false
+		} else {
+			b.WriteRune('\n')
+		}
 		switch {
 		// pad right
 		case n > 0:
-			b.WriteString(l[i])
+			b.WriteString(line)
 			b.WriteString(sp)
 		// pad left
 		default:
 			b.WriteString(sp)
-			b.WriteString(l[i])
-		}
-
-		if i != len(l)-1 {
-			b.WriteRune('\n')
+			b.WriteString(line)
 		}
 	}
 

--- a/style_test.go
+++ b/style_test.go
@@ -473,16 +473,6 @@ func TestStringTransform(t *testing.T) {
 	}
 }
 
-func BenchmarkStyleRender(b *testing.B) {
-	s := NewStyle().
-		Bold(true).
-		Foreground(Color("#ffffff"))
-
-	for i := 0; i < b.N; i++ {
-		s.Render("Hello world")
-	}
-}
-
 func requireTrue(tb testing.TB, b bool) {
 	tb.Helper()
 	requireEqual(tb, true, b)
@@ -569,5 +559,103 @@ func TestHeight(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func BenchmarkPad(b *testing.B) {
+	tests := []struct {
+		name string
+		str  string
+		n    int
+	}{
+		{name: "pad-10", str: "foo bar", n: 10},
+		{name: "pad-100", str: "foo bar", n: 100},
+		{name: "pad-negative-10", str: "foo bar", n: -10},
+		{name: "pad-negative-100", str: "foo bar", n: -100},
+	}
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for b.Loop() {
+				pad(tt.str, tt.n, nil, ' ')
+			}
+		})
+	}
+}
+
+func BenchmarkStyleRender(b *testing.B) {
+	tests := []struct {
+		name  string
+		style Style
+		input string
+	}{
+		{
+			name: "simple-1-line",
+			style: NewStyle().
+				Bold(true).
+				Foreground(Color("#ffffff")),
+			input: "Hello world",
+		},
+		{
+			name: "simple-5-lines",
+			style: NewStyle().
+				Bold(true).
+				Foreground(Color("#ffffff")),
+			input: strings.Repeat("Hello world\n", 5),
+		},
+		{
+			name: "simple-5-lines-inline",
+			style: NewStyle().
+				Bold(true).
+				Foreground(Color("#ffffff")).
+				Inline(true),
+			input: strings.Repeat("Hello world\n", 5),
+		},
+		{
+			name: "simple-10-lines-5-height-40-width",
+			style: NewStyle().
+				Bold(true).
+				Foreground(Color("#ffffff")).
+				Height(5).
+				Width(40),
+			input: strings.Repeat("Hello world\n", 10),
+		},
+		{
+			name: "simple-10-lines-width-maxwidth",
+			style: NewStyle().
+				Bold(true).
+				Foreground(Color("#ffffff")).
+				Width(40).
+				MaxWidth(40),
+			input: strings.Repeat("Hello world\n", 10),
+		},
+		{
+			name: "simple-10-lines-width-maxwidth-borders",
+			style: NewStyle().
+				Bold(true).
+				Foreground(Color("#ffffff")).
+				Width(40).
+				MaxWidth(40).
+				Border(RoundedBorder(), true),
+			input: strings.Repeat("Hello world\n", 10),
+		},
+		{
+			name: "simple-10-lines-width-maxwidth-borders-padding-margins",
+			style: NewStyle().
+				Bold(true).
+				Foreground(Color("#ffffff")).
+				Width(40).
+				MaxWidth(40).
+				Border(RoundedBorder(), true).
+				Padding(1, 1).
+				Margin(1, 1),
+			input: strings.Repeat("Hello world\n", 10),
+		},
+	}
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for b.Loop() {
+				tt.style.Render(tt.input)
+			}
+		})
 	}
 }

--- a/unset.go
+++ b/unset.go
@@ -244,6 +244,19 @@ func (s Style) UnsetBorderLeftForeground() Style {
 	return s
 }
 
+// UnsetBorderBlendForeground removes the border blend foreground color rules,
+// if set.
+func (s Style) UnsetBorderBlendForeground() Style {
+	s.unset(borderBlendForegroundKey)
+	return s
+}
+
+// UnsetBorderBlendWrap removes the border blend wrap style rule, if set.
+func (s Style) UnsetBorderBlendWrap() Style {
+	s.unset(borderBlendWrapKey)
+	return s
+}
+
 // UnsetBorderBackground removes all border background color styles, if
 // set.
 func (s Style) UnsetBorderBackground() Style {


### PR DESCRIPTION
## Changes

- Initial implementation of border blending (gradients).
  - New `Style.BorderBlendForeground(colors...)` method for storing the palette the user wants to use for blending.
  - New `Style.BorderBlendWrap(bool)` method for controlling how the palette is applied.
    - When wrapping is false (**the default**), your palette must specify an end-to-end gradient that ideally blends by itself (the start and end stitching well together).
    - When wrapping is true, the palette is used to generate half of the border, then the other half is the palette in reverse (A->B->C->B->A). This does make it simpler to create a blended border which has ends that stitch well together; however, it has the downside that when used with something like 3 colors, there is more of A and B than of C.
    - Does the name `Wrap` make sense for this?
  - Current blended border always starts from the same position (top left -> top right, -> bottom right -> bottom left -> top left).
  - Associated `Get<X>()` and `Unset<X>()` methods for the above 2 methods.

### Performance notes

- Naturally, blended borders have worse performance than regular borders, especially with the current implementation of how borders are implemented. I tried to keep the current implementation mostly the same for non-blended borders, though there is a small perf loss.
- I made some minor tweaks to other methods in lipgloss to help reduce some of the performance impact, and other simple things technically not related to borders (e.g. `Width()` should be 30-50% less CPU usage, lot of allocs -> 0 allocs).

## Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

---

## Reviewer Notes

- Only foreground blending is supported. I suspect it would be extremely unlikely that users would want background colors blended.
- The wrapping solution I use definitely makes things easier for users. Not sure if it should be the default (though it's not obvious that is how it would work, without maybe really good documentation), and/or if there is a better solution that I can't think of.
- Will still only render the specific border sides depending on what is enabled, but the blending is agnostic to it. As in, it will still internally generate a full blend of the full size, but only apply the colors to the visible borders.
- No current way to change the starting corner (or custom locations). I can easily add the ability to change which side it starts with if that's desired, but custom locations would be a challenge, unless we supported passing in a 1-to-1 colors array that exactly matches the number of border characters (easy for a user to mess up).
  - Maybe the base implementation should be "for simple use cases", and anything else, users could do themselves?
- Ideally, it would be nice to "cache" the generated blend to reduce compute on render, but I couldn't think of a simple way of doing this natively.
  - If you generate the blend during `set()` on the style, it won't correctly scale if the size fields change.
  - In one of my projects, I use an in-memory LFU cache based on the size, but that only works well when the palette/wrapping/etc is static.