### PR TITLE
fix: include borders in width calculation

### DIFF
--- a/style.go
+++ b/style.go
@@ -364,10 +364,12 @@ func (s Style) Render(strs ...string) string {
 
 	// Word wrap
 	if !inline && width > 0 {
-		// Include border widths in available inner width so that the
-		// overall rendered width (including borders) matches the set width.
+		// Include padding and border widths in available inner width so the
+		// overall rendered width (including borders and padding) matches Width.
 		wrapAt := width - leftPadding - rightPadding - s.GetHorizontalBorderSize()
-		str = cellbuf.Wrap(str, wrapAt, "")
+		if wrapAt > 0 {
+			str = cellbuf.Wrap(str, wrapAt, "")
+		}
 	}
 
 	// Render core text
@@ -439,7 +441,9 @@ func (s Style) Render(strs ...string) string {
 			if colorWhitespace || styleWhitespace {
 				st = &teWhitespace
 			}
-			str = alignTextHorizontal(str, horizontalAlign, width, st)
+			// Align to the inner width, excluding borders (padding already applied).
+			innerWidth := max(0, width-s.GetHorizontalBorderSize())
+			str = alignTextHorizontal(str, horizontalAlign, innerWidth, st)
 		}
 	}
 

--- a/style_test.go
+++ b/style_test.go
@@ -593,7 +593,7 @@ func TestCarriageReturnInRender(t *testing.T) {
 
 func TestWidthIncludesBorders(t *testing.T) {
 	s := NewStyle().BorderStyle(NormalBorder()).Width(10)
-	out := s.Render("hi")
+	out := s.Render("12345678901234567890")
 	if w := Width(out); w != 10 {
 		t.Fatalf("expected total width 10, got %d. Output: %s", w, out)
 	}
@@ -603,9 +603,9 @@ func TestWidthIncludesBordersWithPadding(t *testing.T) {
 	s := NewStyle().
 		BorderStyle(NormalBorder()).
 		Padding(1, 2, 1, 3).
-		Width(20)
-	out := s.Render("hello")
-	if w := Width(out); w != 20 {
-		t.Fatalf("expected total width 20, got %d. Output: %s", w, out)
+		Width(10)
+	out := s.Render("12345678901234567890")
+	if w := Width(out); w != 10 {
+		t.Fatalf("expected total width 10, got %d. Output: %s", w, out)
 	}
 }


### PR DESCRIPTION
Fix for https://github.com/charmbracelet/lipgloss/issues/298#issuecomment-2512430754

This PR ensures Style.Width() applies to the total rendered width, including borders and padding. This fixes cases where text with borders overflowed the set width.
- Wrap width now subtracts both padding and border size.
- Horizontal alignment uses the inner width (excluding borders).
- Added tests to verify rendered output never exceeds the configured width.

![demo](https://github.com/user-attachments/assets/8d8ca62b-fac2-4f7a-8704-142509c50f30)

Example program to see the issue live:
```go
package main

import (
	"fmt"

	"github.com/charmbracelet/bubbles/list"
	tea "github.com/charmbracelet/bubbletea"
	"github.com/charmbracelet/lipgloss"
)

type item struct {
	title string
	desc  string
}

func (i item) Title() string       { return i.title }
func (i item) Description() string { return i.desc }
func (i item) FilterValue() string { return i.title }

type model struct {
	list           list.Model
	width          int
	containerStyle lipgloss.Style
}

func newModel() model {
	items := make([]list.Item, 0, 10)
	for n := 1; n <= 10; n++ {
		items = append(items, item{
			title: fmt.Sprintf("Item %d", n),
			desc:  "Placeholder description",
		})
	}

	delegate := list.NewDefaultDelegate()
	l := list.New(items, delegate, 0, 0)
	l.Title = "Test"

	m := model{list: l}
	m.containerStyle = lipgloss.NewStyle().
		Border(lipgloss.RoundedBorder()).
		Padding(0, 1)
	return m
}

func (m model) Init() tea.Cmd { return nil }

func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
	switch msg := msg.(type) {
	case tea.WindowSizeMsg:
		m.width = msg.Width
		wFrame, hFrame := m.containerStyle.GetFrameSize()
		wList := msg.Width - wFrame
		hList := msg.Height - hFrame
		m.list.SetSize(wList, hList)
		return m, nil
	default:
		var cmd tea.Cmd
		m.list, cmd = m.list.Update(msg)
		return m, cmd
	}
}

func (m model) View() string {
	c := m.containerStyle
	s := c.Width(m.width)
	return s.Render(m.list.View())
}

func main() {
	p := tea.NewProgram(newModel(), tea.WithAltScreen())
	if _, err := p.Run(); err != nil {
		fmt.Println("Error:", err)
	}
}
```