### PR TITLE
Issue 108 Fix: Stopped tab space infinite loop

### DIFF
--- a/whitespace.go
+++ b/whitespace.go
@@ -9,9 +9,10 @@ import (
 
 // whitespace is a whitespace renderer.
 type whitespace struct {
-	re    *Renderer
-	style termenv.Style
-	chars string
+	re       *Renderer
+	style    termenv.Style
+	chars    string
+	tabWidth int
 }
 
 // newWhitespace creates a new whitespace renderer. The order of the options
@@ -19,8 +20,9 @@ type whitespace struct {
 // other options might depend on it.
 func newWhitespace(r *Renderer, opts ...WhitespaceOption) *whitespace {
 	w := &whitespace{
-		re:    r,
-		style: r.ColorProfile().String(),
+		re:       r,
+		style:    r.ColorProfile().String(),
+		tabWidth: 4, // default tab width
 	}
 	for _, opt := range opts {
 		opt(w)
@@ -32,6 +34,11 @@ func newWhitespace(r *Renderer, opts ...WhitespaceOption) *whitespace {
 func (w whitespace) render(width int) string {
 	if w.chars == "" {
 		w.chars = " "
+	}
+
+	// replaces tabs with spaces matching tabWidth
+	if strings.Contains(w.chars, "\t") {
+		w.chars = strings.ReplaceAll(w.chars, "\t", strings.Repeat(" ", w.tabWidth))
 	}
 
 	r := []rune(w.chars)
@@ -79,5 +86,12 @@ func WithWhitespaceBackground(c TerminalColor) WhitespaceOption {
 func WithWhitespaceChars(s string) WhitespaceOption {
 	return func(w *whitespace) {
 		w.chars = s
+	}
+}
+
+// WithWhitespaceTabWidth sets the tab width, which has a default of 4
+func WithWhitespaceTabWidth(width int) WhitespaceOption {
+	return func(w *whitespace) {
+		w.tabWidth = max(-1, width)
 	}
 }

--- a/whitespace_test.go
+++ b/whitespace_test.go
@@ -1,0 +1,95 @@
+package lipgloss
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+// TestPlaceWithTabCharacterHang tests that Place doesn't hang when using
+// tab characters with WithWhitespaceChars option.
+func TestPlaceWithTabCharacterHang(t *testing.T) {
+	// Set up a timeout to prevent test from hanging indefinitely
+	done := make(chan bool)
+
+	go func() {
+		// This should not hang
+		_ = Place(10, 3, Center, Center, "hello",
+			WithWhitespaceChars("\t"),
+		)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Test passed - function completed
+	case <-time.After(2 * time.Second):
+		t.Fatal("Place() hung when using tab character in WithWhitespaceChars - issue #108")
+	}
+}
+
+// TestPlaceWithTabVariations tests various tab character combinations
+func TestPlaceWithTabVariations(t *testing.T) {
+	testCases := []struct {
+		name  string
+		chars string
+	}{
+		{"tab character", "\t"},
+		{"multiple tabs", "\t\t"},
+		{"tab and space", "\t "},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan bool)
+
+			go func() {
+				_ = Place(10, 3, Center, Center, "hello",
+					WithWhitespaceChars(tc.chars),
+				)
+				done <- true
+			}()
+
+			select {
+			case <-done:
+				// Test passed
+			case <-time.After(2 * time.Second):
+				t.Fatalf("Place() hung with whitespace chars %q", tc.chars)
+			}
+		})
+	}
+}
+
+// TestWhitespaceRenderWithTabChar tests the whitespace.render method directly with tabs
+func TestWhitespaceRenderWithTabChar(t *testing.T) {
+	r := NewRenderer(io.Discard)
+
+	testCases := []struct {
+		name  string
+		chars string
+		width int
+	}{
+		{"tab character small width", "\t", 5},
+		{"tab character large width", "\t", 20},
+		{"multiple tabs", "\t\t", 10},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan bool)
+
+			go func() {
+				ws := newWhitespace(r, WithWhitespaceChars(tc.chars))
+				_ = ws.render(tc.width)
+				done <- true
+			}()
+
+			select {
+			case <-done:
+				// Test passed
+			case <-time.After(2 * time.Second):
+				t.Fatalf("whitespace.render() hung with chars %q and width %d", tc.chars, tc.width)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Converts tabs into spaces by adding a field to whitespace struct, which has a default of 4, and a WithWhitespaceTabWidth option to control tab width, but defaults to 4.

- [y] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
