### PR TITLE
fix(canvas): handle misc edge cases

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -58,6 +58,11 @@ func (c *Canvas) Hit(x, y int) string {
 
 // AddLayers adds the given layers to the Canvas.
 func (c *Canvas) AddLayers(layers ...*Layer) {
+	for i, layer := range layers {
+		if layer == nil {
+			panic(fmt.Sprintf("layer at index %d is nil", i))
+		}
+	}
 	c.layers = append(c.layers, layers...)
 	sortLayers(c.layers, false)
 }
@@ -204,7 +209,10 @@ func (l *Layer) GetHeight() int {
 // AddLayers adds child layers to the Layer.
 func (l *Layer) AddLayers(layers ...*Layer) *Layer {
 	// Make children relative to the parent
-	for _, child := range layers {
+	for i, child := range layers {
+		if child == nil {
+			panic(fmt.Sprintf("layer at index %d is nil", i))
+		}
 		child.rect = child.rect.Add(l.rect.Min)
 		child.zIndex += l.zIndex
 	}
@@ -215,6 +223,12 @@ func (l *Layer) AddLayers(layers ...*Layer) *Layer {
 
 // SetContent sets the content of the Layer.
 func (l *Layer) SetContent(content any) *Layer {
+	if content == nil {
+		l.content = nil
+		l.rect = image.Rectangle{}
+		return l
+	}
+
 	var drawable uv.Drawable
 	var rect image.Rectangle
 	switch c := content.(type) {
@@ -255,10 +269,9 @@ func (l *Layer) Content() any {
 
 // Draw draws the Layer onto the given screen buffer.
 func (l *Layer) Draw(scr uv.Screen, area image.Rectangle) {
-	if l.content == nil {
-		return
+	if l.content != nil {
+		l.content.Draw(scr, area.Intersect(l.Bounds()))
 	}
-	l.content.Draw(scr, area.Intersect(l.Bounds()))
 	for _, child := range l.children {
 		if child.content == nil {
 			continue


### PR DESCRIPTION
### Changes in this PR

- Allow using `lipgloss.NewLayer(nil)` (or the default value of `&lipgloss.Layer{}`), to still render children (like is the case for child -> child layers).
  - Additionally, when using a layer to wrap multiple children layers, this means we can reduce allocations, as currently, a layer has to have a content field set, in order for children to be drawn.
- Panic on `AddLayers()` in both canvas and layers with a more clear message indicating the mistake, when someone passes nil layers. When nil layers are passed to canvas, it will panic fairly deep, so this just does that validation sooner, with a more clear message.

Currently:

- a layer must specify it's content as `""` in order for children to render
- however, children of a layer don't require the same enforcement. i.e. layer1 (has to have content) -> layer2 (doesn't have to have content) -> layer3 (with content).

---

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
