### PR TITLE
v2: layers: allow recursive rendering when a layer only contains children

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -273,10 +273,7 @@ func (l *Layer) Draw(scr uv.Screen, area image.Rectangle) {
 		l.content.Draw(scr, area.Intersect(l.Bounds()))
 	}
 	for _, child := range l.children {
-		if child.content == nil {
-			continue
-		}
-		child.content.Draw(scr, area.Intersect(child.Bounds()))
+		child.Draw(scr, area.Intersect(child.Bounds()))
 	}
 }
 


### PR DESCRIPTION
## Changes in this PR

This is a follow-up to https://github.com/charmbracelet/lipgloss/pull/588, which is an effort to allow using layers for more complex layouts without a root model having to know everything about all children (without having to allocate additional memory).

The tl;dr: Allows a child layer of another layer to still have all of its children be rendered, even if the layer itself doesn't draw its own cells. Rather than the parent checking if the child has a content field set, it will just call `Draw(...)` on the layer, and the layer will render whatever it can, recursively down the tree.

Prior to this change, the below example code would not render the cards, but would still render the footer:

```go
package main

import (
	"fmt"
	"os"

	tea "charm.land/bubbletea/v2"
	"charm.land/lipgloss/v2"
	"github.com/charmbracelet/x/exp/charmtone"
)

type model struct {
	width  int
	height int
}

func (m model) Init() tea.Cmd {
	return nil
}

func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
	switch msg := msg.(type) {
	case tea.WindowSizeMsg:
		m.width = msg.Width
		m.height = msg.Height
		return m, nil
	case tea.KeyPressMsg:
		switch msg.String() {
		case "q", "ctrl+c", "esc":
			return m, tea.Quit
		}
	}
	return m, nil
}

func (m model) View() tea.View {
	var view tea.View
	view.AltScreen = true

	view.SetContent(lipgloss.NewCanvas(
		lipgloss.NewLayer(nil).Width(m.width).Height(m.height).Z(1).AddLayers( // Vertical stack, fills entire screen.
			lipgloss.NewLayer(nil).Width(m.width).Height(m.height-1).Z(2).AddLayers( // Encapsulate z stack -- should fill all but the bottom line.
				lipgloss.NewLayer(newCard("Hello")).X(0).Y(0).Z(3).Width(20).Height(10),
				lipgloss.NewLayer(newCard("Goodbye")).X(4).Y(2).Z(3).Width(20).Height(10), // Slightly offset from the first card.
			),
			lipgloss.NewLayer(
				lipgloss.NewStyle().
					Foreground(charmtone.Oyster).
					AlignVertical(lipgloss.Bottom).
					Render("Press any key to swap the cards, or q to quit."),
			).Y(m.height-1).Z(2).Width(m.width).Height(1),
		),
	))

	return view
}

func newCard(str string) string {
	return lipgloss.NewStyle().
		Width(20).
		Height(10).
		Border(lipgloss.RoundedBorder()).
		BorderForeground(charmtone.Charple).
		Align(lipgloss.Center, lipgloss.Center).
		Render(str)
}

func main() {
	if _, err := tea.NewProgram(model{}).Run(); err != nil {
		fmt.Fprintln(os.Stderr, "Urgh:", err)
		os.Exit(1)
	}
}
```

---

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
