### PR TITLE
perf: improve performance of maxRuneWidth

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -5,8 +5,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/charmbracelet/x/ansi"
+	"github.com/clipperhouse/displaywidth"
 	"github.com/muesli/termenv"
-	"github.com/rivo/uniseg"
 )
 
 // Border contains a series of values which comprise the various parts of a
@@ -57,10 +57,7 @@ func (b Border) GetLeftSize() int {
 
 func getBorderEdgeWidth(borderParts ...string) (maxWidth int) {
 	for _, piece := range borderParts {
-		w := maxRuneWidth(piece)
-		if w > maxWidth {
-			maxWidth = w
-		}
+		maxWidth = max(maxWidth, maxRuneWidth(piece))
 	}
 	return maxWidth
 }
@@ -468,17 +465,19 @@ func (s Style) styleBorder(border string, fg, bg TerminalColor) string {
 }
 
 func maxRuneWidth(str string) int {
-	var width int
-
-	state := -1
-	for len(str) > 0 {
-		var w int
-		_, str, w, state = uniseg.FirstGraphemeClusterInString(str, state)
-		if w > width {
-			width = w
-		}
+	switch len(str) {
+	case 0:
+		return 0
+	case 1:
+		return displaywidth.String(str)
 	}
 
+	var width int
+
+	g := displaywidth.StringGraphemes(str)
+	for g.Next() {
+		width = max(width, g.Width())
+	}
 	return width
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.10.2
 	github.com/charmbracelet/x/cellbuf v0.0.13
 	github.com/charmbracelet/x/exp/golden v0.0.0-20250609102027-b60490452b30
+	github.com/clipperhouse/displaywidth v0.6.2
 	github.com/muesli/termenv v0.16.0
 	github.com/rivo/uniseg v0.4.7
 )
@@ -19,6 +20,8 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/clipperhouse/stringish v0.1.1 // indirect
+	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,12 @@ github.com/charmbracelet/x/exp/golden v0.0.0-20250609102027-b60490452b30 h1:lF42
 github.com/charmbracelet/x/exp/golden v0.0.0-20250609102027-b60490452b30/go.mod h1:IfZAMTHB6XkZSeXUqriemErjAWCCzT0LwjKFYCZyw0I=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
+github.com/clipperhouse/displaywidth v0.6.2 h1:ZDpTkFfpHOKte4RG5O/BOyf3ysnvFswpyYrV7z2uAKo=
+github.com/clipperhouse/displaywidth v0.6.2/go.mod h1:R+kHuzaYWFkTm7xoMmK1lFydbci4X2CicfbGstSGg0o=
+github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
+github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
+github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
+github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

A little optimization on `maxRuneWidth`, looks like ~2x.

```
goos: darwin
goarch: arm64
pkg: github.com/charmbracelet/lipgloss
cpu: Apple M2

BenchmarkMaxRuneWidth/Blank/Before-8  	       6.832 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxRuneWidth/Blank/After-8   	       2.110 ns/op	       0 B/op	       0 allocs/op

BenchmarkMaxRuneWidth/Markdown/Before-8        6.755 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxRuneWidth/Markdown/After-8         2.060 ns/op	       0 B/op	       0 allocs/op

BenchmarkMaxRuneWidth/Normal/Before-8         32.11 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxRuneWidth/Normal/After-8          14.55 ns/op	       0 B/op	       0 allocs/op

BenchmarkMaxRuneWidth/Rounded/Before-8        30.79 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxRuneWidth/Rounded/After-8         14.57 ns/op	       0 B/op	       0 allocs/op

BenchmarkMaxRuneWidth/Block/Before-8          33.84 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxRuneWidth/Block/After-8           14.65 ns/op	       0 B/op	       0 allocs/op

BenchmarkMaxRuneWidth/Emoji/Before-8          29.45 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxRuneWidth/Emoji/After-8           15.38 ns/op	       0 B/op	       0 allocs/op
```