### PR TITLE
fix: render unset border sides when only some sides are disabled

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -279,10 +279,10 @@ func ASCIIBorder() Border {
 func (s Style) applyBorder(str string) string {
 	var (
 		border    = s.getBorderStyle()
-		hasTop    = s.getAsBool(borderTopKey, false)
-		hasRight  = s.getAsBool(borderRightKey, false)
-		hasBottom = s.getAsBool(borderBottomKey, false)
-		hasLeft   = s.getAsBool(borderLeftKey, false)
+		hasTop    = s.hasBorder(borderTopKey)
+		hasRight  = s.hasBorder(borderRightKey)
+		hasBottom = s.hasBorder(borderBottomKey)
+		hasLeft   = s.hasBorder(borderLeftKey)
 
 		topFG    = s.getAsColor(borderTopForegroundKey)
 		rightFG  = s.getAsColor(borderRightForegroundKey)
@@ -294,15 +294,6 @@ func (s Style) applyBorder(str string) string {
 		bottomBG = s.getAsColor(borderBottomBackgroundKey)
 		leftBG   = s.getAsColor(borderLeftBackgroundKey)
 	)
-
-	// If a border is set and no sides have been specifically turned on or off
-	// render borders on all sides.
-	if s.implicitBorders() {
-		hasTop = true
-		hasRight = true
-		hasBottom = true
-		hasLeft = true
-	}
 
 	// If no border is set or all borders are been disabled, abort.
 	if border == noBorder || (!hasTop && !hasRight && !hasBottom && !hasLeft) {

--- a/get.go
+++ b/get.go
@@ -300,7 +300,7 @@ func (s Style) GetBorderTopWidth() int {
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the top edge, 0 is returned.
 func (s Style) GetBorderTopSize() int {
-	if !s.getAsBool(borderTopKey, false) && !s.implicitBorders() {
+	if !s.hasBorder(borderTopKey) {
 		return 0
 	}
 	return s.getBorderStyle().GetTopSize()
@@ -310,7 +310,7 @@ func (s Style) GetBorderTopSize() int {
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the left edge, 0 is returned.
 func (s Style) GetBorderLeftSize() int {
-	if !s.getAsBool(borderLeftKey, false) && !s.implicitBorders() {
+	if !s.hasBorder(borderLeftKey) {
 		return 0
 	}
 	return s.getBorderStyle().GetLeftSize()
@@ -320,7 +320,7 @@ func (s Style) GetBorderLeftSize() int {
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the left edge, 0 is returned.
 func (s Style) GetBorderBottomSize() int {
-	if !s.getAsBool(borderBottomKey, false) && !s.implicitBorders() {
+	if !s.hasBorder(borderBottomKey) {
 		return 0
 	}
 	return s.getBorderStyle().GetBottomSize()
@@ -330,7 +330,7 @@ func (s Style) GetBorderBottomSize() int {
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the right edge, 0 is returned.
 func (s Style) GetBorderRightSize() int {
-	if !s.getAsBool(borderRightKey, false) && !s.implicitBorders() {
+	if !s.hasBorder(borderRightKey) {
 		return 0
 	}
 	return s.getBorderStyle().GetRightSize()
@@ -531,6 +531,35 @@ func (s Style) implicitBorders() bool {
 		leftSet     = s.isSet(borderLeftKey)
 	)
 	return borderStyle != noBorder && !(topSet || rightSet || bottomSet || leftSet) //nolint:staticcheck
+}
+
+// hasBorder returns whether a specific border side should be rendered.
+// If the side has been explicitly set, its value is used. If not set, the
+// default depends on context:
+//   - If no sides are explicitly set: default to true (all sides render).
+//   - If any side is explicitly enabled (true): default to false (only enabled
+//     sides render, matching the old behavior for e.g. BorderTop(true)).
+//   - If sides are only explicitly disabled (false) with none enabled: default
+//     to true (unset sides still render). This fixes #194 and #366 where
+//     BorderTop(false).BorderRight(false).BorderBottom(false) should still
+//     render the left border.
+func (s Style) hasBorder(side propKey) bool {
+	if s.isSet(side) {
+		return s.getAsBool(side, false)
+	}
+	if s.getBorderStyle() == noBorder {
+		return false
+	}
+	// Check whether any side was explicitly turned on.
+	for _, k := range []propKey{borderTopKey, borderRightKey, borderBottomKey, borderLeftKey} {
+		if s.isSet(k) && s.getAsBool(k, false) {
+			// At least one side is explicitly enabled, so unset sides
+			// default to off (preserves "opt-in" behaviour).
+			return false
+		}
+	}
+	// No side was explicitly enabled; unset sides default to on.
+	return true
 }
 
 func (s Style) getAsTransform(propKey) func(string) string {


### PR DESCRIPTION
## Summary

Fixes #366 and #194: When a border style is set and some sides are explicitly disabled (e.g. `BorderTop(false)`), the remaining **unset** sides were not rendering.

### Root cause

`implicitBorders()` returns `false` when **any** side is explicitly set, causing unset sides to default to `false` (no border). This makes it impossible to disable specific sides while keeping others via implicit defaults.

### Fix

Add a `hasBorder(side)` method that distinguishes between:
- **Opt-in** (`BorderTop(true)`) → unset sides default to **off** (preserves existing behavior)
- **Opt-out** (`BorderTop(false)`) → unset sides default to **on** (fixes the reported bugs)

### Reproducer from #366

```go
leftOnly := NewStyle().
    BorderStyle(Border{Left: "   new             "}).
    BorderForeground(Color("#FFA500"))
got := leftOnly.isSet(borderLeftKey) // was: false, now: correctly renders
```

### Reproducer from #194

```go
leftOnly := NewStyle().
    BorderStyle(Border{Left: "..."}).
    BorderTop(false).
    BorderRight(false).
    BorderBottom(false).
    BorderForeground(neonOrange)
// Left border now renders correctly
```

All existing tests pass (`go test ./...`).

---

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*