### PR TITLE
fix: handle partial reads in queryTerminal

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -94,19 +94,26 @@ func queryTerminal(
 	pa := ansi.GetParser()
 	defer ansi.PutParser(pa)
 
+	var acc []byte // Accumulate partial responses before filtering
 	var buf [256]byte // 256 bytes should be enough for most responses
+	var state byte
 	for {
 		n, err := rd.Read(buf[:])
 		if err != nil {
 			return fmt.Errorf("could not read from input: %w", err)
 		}
 
-		var state byte
 		p := buf[:]
 		for n > 0 {
 			seq, _, read, newState := ansi.DecodeSequence(p[:n], state, pa)
-			if !filter(string(seq), pa) {
-				return nil
+			acc = append(acc, seq...)
+
+			if newState == ansi.NormalState {
+				if !filter(string(acc), pa) {
+					return nil
+				}
+
+				acc = acc[:0]
 			}
 
 			state = newState


### PR DESCRIPTION
**Note**: re-opening #616 after `v2-exp` merge

### What is broken?

This all started with `lipgloss.HasDarkBackground` timing out most (80%?) of the time when running in Windows Terminal.

After ignoring the problem for a few weeks, I finally decided to figure out what was happening: `queryBackgroundColor` sends an OSC 11 and a CSI DA1 request one after the other and is supposed to receive back (at least) one response of each type.

The code (with a couple of debug statements) running in the VSCode integrated terminal:

```bash
Read 25 bytes: "\x1b]11;rgb:1f1f/2424/3030\x1b\\"
Received sequence: "\x1b]11;rgb:1f1f/2424/3030\x1b\\", state: 0, command: 11, data: "11;rgb:1f1f/2424/3030"
Read 7 bytes: "\x1b[?1;2c"
Received sequence: "\x1b[?1;2c", state: 0, command: 16227, data: ""
```

The same code in Windows Terminal:

```bash
Read 16 bytes: "\x1b]11;rgb:1a1a/1b"
Received sequence: "\x1b]11;rgb:1a1a/1b", state: 5, command: 11, data: "11;rgb:1a1a/1b"
Read 7 bytes: "1b/2626"
Received sequence: "1b/2626", state: 5, command: 11, data: "11;rgb:1a1a/1b1b/2626"
Read 2 bytes: "\x1b\\"
Received sequence: "\x1b\\", state: 0, command: 11, data: "11;rgb:1a1a/1b1b/2626"
Read 16 bytes: "\x1b[?61;4;6;7;14;2"
Received sequence: "\x1b[?61;4;6;7;14;2", state: 2, command: 16128, data: ""
Read 16 bytes: "1;22;23;24;28;32"
Received sequence: "1;22;23;24;28;32", state: 2, command: 16128, data: ""
Read 7 bytes: ";42;52c"
Received sequence: ";42;52c", state: 0, command: 16227, data: ""
```

As you can see, the terminal response is being received in chunks. Lipgloss assumes that somehow we will always end the read on a sequence boundary, and:
- Resets the parser state between reads
- Sends every partial read to `filter()` regardless of the current parser state.

This causes `filter()` to:
- Fail to parse the color (the least of our problems)
- Fail to recognize the DA1 response, thus never exiting the loop until the cancel reader times out

### What am I changing?

The patch makes sure that we only ever send complete sequences to `filter()`, while maintaining the parser state in between reads so that we can successfully complete parsing a sequence even if it's split inconveniently.

If you have any better ideas on how to implement this, please feel free to propose them :)

---

Side note, in all terminals I use the CSI DA1 request causes the terminal to return the background and foreground colors in addition to the DA1 response. I feel like maybe there's an opportunity to simplify `queryBackgroundColor`, but I don't know how this behaves in other terminal emulators.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).