### PR TITLE
fix: add missing underlineColorKey case in getAsColor

### DIFF
--- a/get.go
+++ b/get.go
@@ -550,6 +550,8 @@ func (s Style) getAsColor(k propKey) color.Color {
 		c = s.borderBottomBgColor
 	case borderLeftBackgroundKey:
 		c = s.borderLeftBgColor
+	case underlineColorKey:
+		c = s.ulColor
 	}
 
 	if c != nil {

--- a/style_test.go
+++ b/style_test.go
@@ -34,6 +34,10 @@ func TestUnderline(t *testing.T) {
 			NewStyle().UnderlineStyle(UnderlineCurly),
 			"\x1b[4;4:3ma\x1b[m\x1b[4;4:3mb\x1b[m\x1b[4m \x1b[m\x1b[4;4:3mc\x1b[m",
 		},
+		{
+			NewStyle().UnderlineStyle(UnderlineCurly).UnderlineColor(Color("#FF0000")),
+			"\x1b[4;58;2;255;0;0;4:3ma\x1b[m\x1b[4;58;2;255;0;0;4:3mb\x1b[m\x1b[58;2;255;0;0;4m \x1b[m\x1b[4;58;2;255;0;0;4:3mc\x1b[m",
+		},
 	}
 
 	for i, tc := range tt {
@@ -44,6 +48,16 @@ func TestUnderline(t *testing.T) {
 				i, tc.expected,
 				res)
 		}
+	}
+}
+
+func TestGetUnderlineColor(t *testing.T) {
+	t.Parallel()
+
+	red := Color("#FF0000")
+	s := NewStyle().Underline(true).UnderlineColor(red)
+	if s.GetUnderlineColor() != red {
+		t.Errorf("GetUnderlineColor() = %v, want %v", s.GetUnderlineColor(), red)
 	}
 }
 


### PR DESCRIPTION
## Summary

`UnderlineColor()` has no effect because `underlineColorKey` is missing from the `switch` in `getAsColor()`. The setter stores the color in `s.ulColor`, but both `GetUnderlineColor()` and the `Render()` path call `getAsColor(underlineColorKey)` which falls through to `noColor`.

This one-line fix adds the missing case.

## Repro

```go
s := lipgloss.NewStyle().
    Foreground(lipgloss.Color("#FFFFFF")).
    UnderlineStyle(lipgloss.UnderlineCurly).
    UnderlineColor(lipgloss.Color("#FF0000"))

fmt.Printf("%q\n", s.Render("Hello"))
// Before: no 58;2;255;0;0 in output — underline color is ignored
// After:  58;2;255;0;0 present — red underline renders correctly
```

## Test plan

- Added render test case for `UnderlineStyle` + `UnderlineColor` combined
- Added `TestGetUnderlineColor` for the getter
- All existing tests pass