### PR TITLE
fix: replace newlines with spaces in Inline mode

### DIFF
--- a/style.go
+++ b/style.go
@@ -399,9 +399,9 @@ func (s Style) Render(strs ...string) string {
 	// carriage returns can cause strange behaviour when rendering.
 	str = strings.ReplaceAll(str, "\r\n", "\n")
 
-	// Strip newlines in single line mode
+	// Replace newlines with spaces in single line mode
 	if inline {
-		str = strings.ReplaceAll(str, "\n", "")
+		str = strings.ReplaceAll(str, "\n", " ")
 	}
 
 	// Include borders in block size.

--- a/style_test.go
+++ b/style_test.go
@@ -530,6 +530,17 @@ func TestCarriageReturnInRender(t *testing.T) {
 	}
 }
 
+func TestInlineReplacesNewlinesWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	s := NewStyle().Inline(true)
+	got := s.Render("hello\nworld")
+	want := "hello world"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
 func TestWidth(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

- Fixes #116: `Inline(true)` now replaces newlines with spaces instead of stripping them entirely
- `style.Render("hello\nworld")` with `Inline(true)` now produces `"hello world"` instead of `"helloworld"`
- Adds a test to verify the correct behavior

## Details

The single-character change in `style.go` line 404 replaces `""` with `" "` in the newline replacement, preserving word boundaries when rendering inline text. This matches the expected behavior described in the issue — newlines should become spaces, not disappear.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New `TestInlineReplacesNewlinesWithSpaces` test added and passing
- [ ] Manual verification: `NewStyle().Inline(true).Render("hello\nworld")` returns `"hello world"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)