### PR TITLE
docs: fix tree comment typo

### DIFF
--- a/tree/tree.go
+++ b/tree/tree.go
@@ -156,7 +156,7 @@ func (t *Tree) String() string {
 
 // Child adds a child to this Tree.
 //
-// If a Child Tree is passed without a root, it will be parented to it's sibling
+// If a Child Tree is passed without a root, it will be parented to its sibling
 // child (auto-nesting).
 //
 //	tree.Root("Foo").Child("Bar", tree.New().Child("Baz"), "Qux")


### PR DESCRIPTION
## Summary
- fix a typo in the tree package comment
- keep the change limited to one file with no behavior impact

## Related issue
- N/A

## Guideline alignment
- Minimal comment-only change aligned with the repo contribution guidance: https://github.com/charmbracelet/lipgloss/contribute

## Validation/testing
- Not run; comment-only change
