### PR TITLE
fix: Avoid background color query hang

### DIFF
--- a/query.go
+++ b/query.go
@@ -54,13 +54,16 @@ func BackgroundColor(in term.File, out term.File) (bg color.Color, err error) {
 	}
 
 	// NOTE: On Unix, one of the given files must be a tty.
+	if !term.IsTerminal(in.Fd()) || !term.IsTerminal(out.Fd()) {
+		return nil, fmt.Errorf("input/output is not a terminal")
+	}
 	for _, f := range []term.File{in, out} {
 		if bg, err = backgroundColor(f, f); err == nil {
 			return bg, nil
 		}
 	}
 
-	return
+	return bg, err
 }
 
 // HasDarkBackground detects whether the terminal has a light or dark


### PR DESCRIPTION
Which seems to happen if stdin/stdout are somehow accidentally not TTYs.

Potential fix for https://github.com/charmbracelet/lipgloss/issues/635? Might need more fixes here, but this at least seems to make things work for my use case.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
