### PR TITLE
docs: amend inline docs for height calculation

### DIFF
--- a/size.go
+++ b/size.go
@@ -23,9 +23,9 @@ func Width(str string) (width int) {
 	return width
 }
 
-// Height returns height of a string in cells. This is done simply by
-// counting \n characters. If your output has \r\n, that sequence will be
-// replaced with a \n in [Style.Render].
+// Height returns height of a string in cells, calculated simply
+// as 1 plus the number of \n characters. If your output has \r\n,
+// that sequence will be replaced with a \n in [Style.Render].
 func Height(str string) int {
 	return strings.Count(str, "\n") + 1
 }


### PR DESCRIPTION
Adding clarity here can help us to avoid situations where a developer may read the documentation via IDE tooling and work on a false assumption that `lipgloss.Height` does not account for the fact that at least one line in the input string won't have a newline, when in fact it does (hence the `+1`).

I contend that we have already seen an [example of this](https://github.com/charmbracelet/bubbles/pull/914) likely occurring within the `filepicker` model in the `bubbles` repo.