### PR TITLE
feat: allow multi-character corners on borders

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -403,11 +403,7 @@ func (s Style) applyBorder(str string) string {
 		}
 	}
 
-	// For now, limit corners to one rune.
-	border.TopLeft = getFirstRuneAsString(border.TopLeft)
-	border.TopRight = getFirstRuneAsString(border.TopRight)
-	border.BottomRight = getFirstRuneAsString(border.BottomRight)
-	border.BottomLeft = getFirstRuneAsString(border.BottomLeft)
+	// Multi-character corners are supported. No truncation is applied.
 
 	var topFG, rightFG, bottomFG, leftFG color.Color
 	var (

--- a/borders_test.go
+++ b/borders_test.go
@@ -177,6 +177,53 @@ func BenchmarkGetFirstRuneAsString(b *testing.B) {
 	})
 }
 
+func TestMultiCharCorners(t *testing.T) {
+	// Multi-character corners should not be truncated (issue #605).
+	border := Border{
+		Top:         "─",
+		Bottom:      "─",
+		Left:        "│",
+		Right:       "│",
+		TopLeft:     "╔═",
+		TopRight:    "═╗",
+		BottomLeft:  "╚═",
+		BottomRight: "═╝",
+	}
+
+	style := NewStyle().
+		Border(border, true).
+		Width(10)
+
+	result := style.Render("hi")
+
+	// The multi-character corners should appear in the output.
+	if !containsString(result, "╔═") {
+		t.Errorf("expected multi-char top-left corner '╔═' in output, got:\n%s", result)
+	}
+	if !containsString(result, "═╗") {
+		t.Errorf("expected multi-char top-right corner '═╗' in output, got:\n%s", result)
+	}
+	if !containsString(result, "╚═") {
+		t.Errorf("expected multi-char bottom-left corner '╚═' in output, got:\n%s", result)
+	}
+	if !containsString(result, "═╝") {
+		t.Errorf("expected multi-char bottom-right corner '═╝' in output, got:\n%s", result)
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && stringContains(s, substr))
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
 func BenchmarkMaxRuneWidth(b *testing.B) {
 	testCases := []struct {
 		name string


### PR DESCRIPTION
## Summary
- Remove the single-rune truncation limitation for border corners (`TopLeft`, `TopRight`, `BottomLeft`, `BottomRight`)
- Multi-character strings are now fully supported for all corner fields, enabling richer border designs
- Added test coverage for multi-character corner rendering

Closes #605

## Test plan
- [x] Existing border tests pass
- [x] New `TestMultiCharCorners` validates multi-character corner rendering
- [ ] Manual verification with custom multi-character borders