### PR TITLE
feat(list): add GetItems method to return list items

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -264,6 +264,18 @@ func (l *List) Items(items ...any) *List {
 	return l
 }
 
+// GetItems returns the list's items as a tree.Children interface.
+// This allows iterating over the items in the list.
+//
+//	l := list.New("A", "B", "C")
+//	items := l.GetItems()
+//	for i := range items.Length() {
+//		fmt.Println(items.At(i).Value())
+//	}
+func (l *List) GetItems() Items {
+	return l.tree.Children()
+}
+
 // Enumerator sets the list enumerator.
 //
 // There are several predefined enumerators:


### PR DESCRIPTION
## Summary
- Add `GetItems()` method to `List` that returns the list's children as an `Items` interface
- Allows programmatic iteration over list items after construction (e.g., `items.At(i).Value()`)

Closes #320

## Test plan
- [x] All existing list tests pass
- [ ] Manual test: create a list, call `GetItems()`, iterate and verify values