### PR TITLE
feat(tree): expose node depth for style functions

### DIFF
--- a/tree/renderer.go
+++ b/tree/renderer.go
@@ -9,12 +9,23 @@ import (
 // StyleFunc allows the tree to be styled per item.
 type StyleFunc func(children Children, i int) lipgloss.Style
 
+// DepthStyleFunc allows the tree to be styled per item with depth awareness.
+// The depth parameter indicates the nesting level (0 for root children, 1 for
+// their children, and so on).
+type DepthStyleFunc func(children Children, i int, depth int) lipgloss.Style
+
 // Style is the styling applied to the tree.
 type Style struct {
 	enumeratorFunc StyleFunc
 	indenterFunc   StyleFunc
 	itemFunc       StyleFunc
-	root           lipgloss.Style
+
+	// Depth-aware style functions (take precedence over non-depth variants).
+	enumeratorDepthFunc DepthStyleFunc
+	indenterDepthFunc   DepthStyleFunc
+	itemDepthFunc       DepthStyleFunc
+
+	root lipgloss.Style
 }
 
 // newRenderer returns the renderer used to render a tree.
@@ -45,6 +56,11 @@ type renderer struct {
 
 // render is responsible for actually rendering the tree.
 func (r *renderer) render(node Node, root bool, prefix string) string {
+	return r.renderWithDepth(node, root, prefix, 0)
+}
+
+// renderWithDepth renders the tree while tracking depth for depth-aware styling.
+func (r *renderer) renderWithDepth(node Node, root bool, prefix string, depth int) string {
 	if node.Hidden() {
 		return ""
 	}
@@ -66,6 +82,26 @@ func (r *renderer) render(node Node, root bool, prefix string) string {
 		strs = append(strs, r.style.root.Render(line))
 	}
 
+	// Helper to resolve style functions, preferring depth-aware variants.
+	resolveEnumStyle := func(c Children, i int) lipgloss.Style {
+		if r.style.enumeratorDepthFunc != nil {
+			return r.style.enumeratorDepthFunc(c, i, depth)
+		}
+		return r.style.enumeratorFunc(c, i)
+	}
+	resolveIndentStyle := func(c Children, i int) lipgloss.Style {
+		if r.style.indenterDepthFunc != nil {
+			return r.style.indenterDepthFunc(c, i, depth)
+		}
+		return r.style.indenterFunc(c, i)
+	}
+	resolveItemStyle := func(c Children, i int) lipgloss.Style {
+		if r.style.itemDepthFunc != nil {
+			return r.style.itemDepthFunc(c, i, depth)
+		}
+		return r.style.itemFunc(c, i)
+	}
+
 	for i := range children.Length() {
 		if i < children.Length()-1 {
 			if child := children.At(i + 1); child.Hidden() {
@@ -77,7 +113,7 @@ func (r *renderer) render(node Node, root bool, prefix string) string {
 			}
 		}
 		prefix := enumerator(children, i)
-		prefix = r.style.enumeratorFunc(children, i).Render(prefix)
+		prefix = resolveEnumStyle(children, i).Render(prefix)
 		maxLen = max(lipgloss.Width(prefix), maxLen)
 	}
 
@@ -86,10 +122,10 @@ func (r *renderer) render(node Node, root bool, prefix string) string {
 		if child.Hidden() {
 			continue
 		}
-		indentStyle := r.style.indenterFunc(children, i)
-		enumStyle := r.style.enumeratorFunc(children, i)
+		indentStyle := resolveIndentStyle(children, i)
+		enumStyle := resolveEnumStyle(children, i)
 
-		itemStyle := r.style.itemFunc(children, i)
+		itemStyle := resolveItemStyle(children, i)
 
 		indent := indentStyle.Render(indenter(children, i))
 		nodePrefix := enumStyle.Render(enumerator(children, i))
@@ -152,10 +188,11 @@ func (r *renderer) render(node Node, root bool, prefix string) string {
 					renderer = child.r
 				}
 			}
-			if s := renderer.render(
+			if s := renderer.renderWithDepth(
 				child,
 				false,
 				prefix+indent,
+				depth+1,
 			); s != "" {
 				strs = append(strs, s)
 			}

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -256,6 +256,24 @@ func (t *Tree) EnumeratorStyleFunc(fn StyleFunc) *Tree {
 	return t
 }
 
+// EnumeratorDepthStyleFunc sets the enumeration style function with depth
+// awareness. The depth parameter indicates the nesting level (0 for root
+// children, 1 for their children, and so on).
+//
+// This takes precedence over EnumeratorStyleFunc when set.
+//
+//	t := tree.New().
+//		EnumeratorDepthStyleFunc(func(_ tree.Children, i int, depth int) lipgloss.Style {
+//		    if depth == 0 {
+//		        return lipgloss.NewStyle().Foreground(primaryColor)
+//		    }
+//		    return lipgloss.NewStyle().Foreground(secondaryColor)
+//		})
+func (t *Tree) EnumeratorDepthStyleFunc(fn DepthStyleFunc) *Tree {
+	t.ensureRenderer().style.enumeratorDepthFunc = fn
+	return t
+}
+
 // IndenterStyle sets a static style for all indenters.
 //
 // Use IndenterStyleFunc to conditionally set styles based on the tree node.
@@ -281,6 +299,15 @@ func (t *Tree) IndenterStyleFunc(fn StyleFunc) *Tree {
 		fn = func(Children, int) lipgloss.Style { return lipgloss.NewStyle() }
 	}
 	t.ensureRenderer().style.indenterFunc = fn
+	return t
+}
+
+// IndenterDepthStyleFunc sets the indentation style function with depth
+// awareness. The depth parameter indicates the nesting level.
+//
+// This takes precedence over IndenterStyleFunc when set.
+func (t *Tree) IndenterDepthStyleFunc(fn DepthStyleFunc) *Tree {
+	t.ensureRenderer().style.indenterDepthFunc = fn
 	return t
 }
 
@@ -313,6 +340,28 @@ func (t *Tree) ItemStyleFunc(fn StyleFunc) *Tree {
 		fn = func(Children, int) lipgloss.Style { return lipgloss.NewStyle() }
 	}
 	t.ensureRenderer().style.itemFunc = fn
+	return t
+}
+
+// ItemDepthStyleFunc sets the item style function with depth awareness.
+// The depth parameter indicates the nesting level (0 for root children,
+// 1 for their children, and so on).
+//
+// This takes precedence over ItemStyleFunc when set.
+//
+//	t := tree.New().
+//		ItemDepthStyleFunc(func(_ tree.Children, i int, depth int) lipgloss.Style {
+//		    // Dim items at deeper levels.
+//		    if depth > 1 {
+//		        return lipgloss.NewStyle().Faint(true)
+//		    }
+//		    return lipgloss.NewStyle()
+//		})
+func (t *Tree) ItemDepthStyleFunc(fn DepthStyleFunc) *Tree {
+	if fn == nil {
+		fn = func(Children, int, int) lipgloss.Style { return lipgloss.NewStyle() }
+	}
+	t.ensureRenderer().style.itemDepthFunc = fn
 	return t
 }
 


### PR DESCRIPTION
## Summary
- Add `DepthStyleFunc` type that includes a `depth int` parameter
- Add `EnumeratorDepthStyleFunc`, `IndenterDepthStyleFunc`, and `ItemDepthStyleFunc` methods to `Tree`
- Depth-aware variants take precedence over non-depth variants when set
- Fully backward compatible: existing code is unaffected

Closes #365

## Test plan
- [x] All existing tree tests pass
- [ ] Manual test: create nested tree with `ItemDepthStyleFunc` to verify depth values are correct