### PR TITLE
feat: add consistent enumerators across list and tree packages

### DIFF
--- a/list/enumerator.go
+++ b/list/enumerator.go
@@ -126,3 +126,31 @@ func Asterisk(Items, int) string {
 func Dash(Items, int) string {
 	return "-"
 }
+
+// Tree is an enumeration using tree-style branch characters.
+// It uses the same characters as tree.DefaultEnumerator.
+//
+//	Example:
+//	  ├── Foo
+//	  ├── Bar
+//	  └── Baz
+func Tree(items Items, index int) string {
+	if items.Length()-1 == index {
+		return "└──"
+	}
+	return "├──"
+}
+
+// RoundedTree is an enumeration using tree-style branch characters with
+// rounded corners. It uses the same characters as tree.RoundedEnumerator.
+//
+//	Example:
+//	  ├── Foo
+//	  ├── Bar
+//	  ╰── Baz
+func RoundedTree(items Items, index int) string {
+	if items.Length()-1 == index {
+		return "╰──"
+	}
+	return "├──"
+}

--- a/tree/enumerator.go
+++ b/tree/enumerator.go
@@ -56,6 +56,33 @@ func RoundedEnumerator(children Children, index int) string {
 //	}
 type Indenter func(children Children, index int) string
 
+// BulletEnumerator enumerates tree children with bullets.
+//
+// • Foo
+// • Bar
+// • Baz.
+func BulletEnumerator(Children, int) string {
+	return "•"
+}
+
+// DashEnumerator enumerates tree children with dashes.
+//
+// - Foo
+// - Bar
+// - Baz.
+func DashEnumerator(Children, int) string {
+	return "-"
+}
+
+// AsteriskEnumerator enumerates tree children with asterisks.
+//
+// * Foo
+// * Bar
+// * Baz.
+func AsteriskEnumerator(Children, int) string {
+	return "*"
+}
+
 // DefaultIndenter indents a tree for nested trees and multiline content.
 //
 // ├── Foo


### PR DESCRIPTION
## Summary
- Add tree-style enumerators to the list package: `Tree` and `RoundedTree`
- Add list-style enumerators to the tree package: `BulletEnumerator`, `DashEnumerator`, `AsteriskEnumerator`
- Enables consistent usage patterns across both components

Closes #318

## Test plan
- [x] All existing tests pass
- [ ] Manual test: use `list.Tree` enumerator and `tree.BulletEnumerator` to verify output