### PR TITLE
fix: prevent HasDarkBackground from hanging when no TTY

### DIFF
--- a/query.go
+++ b/query.go
@@ -10,6 +10,12 @@ import (
 )
 
 func backgroundColor(in term.File, out term.File) (color.Color, error) {
+	// Check if input is a terminal before trying to query. Without a TTY,
+	// MakeRaw and the subsequent OSC query will hang indefinitely.
+	if !term.IsTerminal(in.Fd()) {
+		return nil, fmt.Errorf("input is not a terminal")
+	}
+
 	state, err := term.MakeRaw(in.Fd())
 	if err != nil {
 		return nil, fmt.Errorf("error setting raw state to detect background color: %w", err)


### PR DESCRIPTION
## Summary
- Prevent \`HasDarkBackground()\` from hanging when stdin is not a TTY

## Problem
When stdin is piped or redirected (not a terminal), \`backgroundColor()\` called \`term.MakeRaw()\` which blocked, and the subsequent OSC background color query waited indefinitely for a response that never came.

Common scenario:
```bash
echo "test" | my-app  # app hangs on HasDarkBackground()
```

## Fix
Add \`term.IsTerminal(in.Fd())\` check before attempting the query. Returns an error immediately for non-TTY inputs, causing \`HasDarkBackground()\` to fall back to its default (\`true\`) as documented.

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./...\` passes

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)