### PR TITLE
test: add tests for frame size calculation methods

### DIFF
--- a/frame_size_test.go
+++ b/frame_size_test.go
@@ -1,0 +1,64 @@
+package lipgloss
+
+import "testing"
+
+func TestGetHorizontalFrameSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		style Style
+		want  int
+	}{
+		{"empty style", NewStyle(), 0},
+		{"padding only", NewStyle().Padding(0, 2), 4},
+		{"margin only", NewStyle().Margin(0, 3), 6},
+		{"border only", NewStyle().Border(NormalBorder()), 2},
+		{"all combined", NewStyle().Padding(0, 1).Margin(0, 1).Border(NormalBorder()), 6},
+		{"border style without sides", NewStyle().BorderStyle(RoundedBorder()), 2},
+		{"left border only", NewStyle().BorderStyle(NormalBorder()).BorderLeft(true), 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.style.GetHorizontalFrameSize()
+			if got != tt.want {
+				t.Errorf("GetHorizontalFrameSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetVerticalFrameSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		style Style
+		want  int
+	}{
+		{"empty style", NewStyle(), 0},
+		{"padding only", NewStyle().Padding(2, 0), 4},
+		{"margin only", NewStyle().Margin(1, 0), 2},
+		{"border only", NewStyle().Border(NormalBorder()), 2},
+		{"all combined", NewStyle().Padding(1, 0).Margin(1, 0).Border(NormalBorder()), 6},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.style.GetVerticalFrameSize()
+			if got != tt.want {
+				t.Errorf("GetVerticalFrameSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetFrameSize(t *testing.T) {
+	s := NewStyle().Padding(1, 2).Margin(1, 1).Border(RoundedBorder())
+	h, v := s.GetFrameSize()
+	wantH := 2 + 4 + 2 // margin + padding + border
+	wantV := 2 + 2 + 2  // margin + padding + border
+	if h != wantH {
+		t.Errorf("GetFrameSize() horizontal = %d, want %d", h, wantH)
+	}
+	if v != wantV {
+		t.Errorf("GetFrameSize() vertical = %d, want %d", v, wantV)
+	}
+}


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for frame size calculation methods

## Tests Added
- \`TestGetHorizontalFrameSize\` — 7 cases: empty style, padding-only, margin-only, border-only, all combined, BorderStyle without sides, single-side border
- \`TestGetVerticalFrameSize\` — 5 cases covering same scenarios vertically
- \`TestGetFrameSize\` — combined horizontal + vertical with border

## Motivation
These methods are critical for layout calculations but had no dedicated tests. The tests verify that padding, margin, and borders all contribute correctly to the frame size, including the \`isBorderStyleSetWithoutSides()\` edge case.

## Test plan
- [x] All 13 test cases pass

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)