### PR TITLE
fix(tree): fix Offset logic that swapped start and end values

### DIFF
--- a/tree/tree.go
+++ b/tree/tree.go
@@ -118,19 +118,14 @@ func (t *Tree) Hide(hide bool) *Tree {
 // SetHidden hides a Tree node.
 func (t *Tree) SetHidden(hidden bool) { t.Hide(hidden) }
 
-// Offset sets the Tree children offsets.
+// Offset sets the number of children to skip from the start and end of the
+// tree. For example, Offset(2, 1) skips the first 2 and last 1 children.
 func (t *Tree) Offset(start, end int) *Tree {
-	if start > end {
-		_start := start
-		start = end
-		end = _start
-	}
-
 	if start < 0 {
 		start = 0
 	}
-	if end < 0 || end > t.children.Length() {
-		end = t.children.Length()
+	if end < 0 {
+		end = 0
 	}
 
 	t.offset[0] = start


### PR DESCRIPTION
## Summary
- Fix \`tree.Offset()\` swapping start and end values

## Problem
\`Offset(start, end)\` is documented as skip-from-start and skip-from-end. But a swap condition (\`start > end\`) reordered the values:

```go
l.Offset(2, 1) // intended: skip 2 from start, 1 from end
// got: Offset(1, 2) — skip 1 from start, 2 from end (swapped!)
```

## Root Cause
Line 123-127 had \`if start > end { swap }\` which treated the values as absolute indices instead of skip counts.

## Fix
Remove the swap. Both values are skip counts with minimum of 0, matching the render loop: \`for i := offset[0]; i < length-offset[1]\`.

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./tree/...\` passes

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)