### PR TITLE
fix: BorderStyle now sets all border sides by default

### DIFF
--- a/set.go
+++ b/set.go
@@ -522,6 +522,18 @@ func (s Style) Border(b Border, sides ...bool) Style {
 //	lipgloss.NewStyle().BorderStyle(lipgloss.ThickBorder())
 func (s Style) BorderStyle(b Border) Style {
 	s.set(borderStyleKey, b)
+
+	// If no border sides have been explicitly configured, enable all sides
+	// by default. This matches the rendering behavior documented above and
+	// ensures that GetBorderTop/Right/Bottom/Left return consistent results.
+	if !s.isSet(borderTopKey) && !s.isSet(borderRightKey) &&
+		!s.isSet(borderBottomKey) && !s.isSet(borderLeftKey) {
+		s.set(borderTopKey, true)
+		s.set(borderRightKey, true)
+		s.set(borderBottomKey, true)
+		s.set(borderLeftKey, true)
+	}
+
 	return s
 }
 

--- a/style_test.go
+++ b/style_test.go
@@ -741,3 +741,23 @@ func BenchmarkStyleRender(b *testing.B) {
 		})
 	}
 }
+
+func TestBorderStyleDefaultSides(t *testing.T) {
+	t.Parallel()
+
+	// Regression test for https://github.com/charmbracelet/lipgloss/issues/366
+	// BorderStyle should enable all border sides by default when no sides
+	// have been explicitly configured.
+	s := NewStyle().
+		BorderStyle(Border{Left: "   new             "}).
+		BorderForeground(Color("#FFA500"))
+
+	requireTrue(t, s.GetBorderLeft())
+	requireTrue(t, s.GetBorderTop())
+	requireTrue(t, s.GetBorderRight())
+	requireTrue(t, s.GetBorderBottom())
+
+	// BorderStyle should not override explicitly set sides.
+	s2 := NewStyle().BorderLeft(false).BorderStyle(NormalBorder())
+	requireFalse(t, s2.GetBorderLeft())
+}


### PR DESCRIPTION
## Summary

Fixes #366

When calling `BorderStyle()` without explicitly configuring border sides (via `Border()`, `BorderLeft()`, etc.), `GetBorderLeft/Right/Top/Bottom` incorrectly returned `false` even though the border was rendered on all sides during `Render()`. This inconsistency also affected `GetHorizontalFrameSize` vs `GetBorderLeft` — the former correctly returned a non-zero size while the latter returned `false`.

**Root cause:** `BorderStyle()` only set `borderStyleKey` without touching the side keys (`borderTopKey`, etc.). The rendering code in `applyBorder` had a special-case workaround via `isBorderStyleSetWithoutSides()`, but the getter methods did not.

**Fix:** `BorderStyle()` now enables all four border sides when none have been explicitly configured, matching the behavior of `Border()` when called without side arguments. If any side has already been explicitly set (e.g., via `BorderLeft(false)`), the existing configuration is preserved.

## Reproducer from issue

```go
leftOnly := NewStyle().
    BorderStyle(Border{Left: "   new             "}).
    BorderForeground(Color("#FFA500"))

// Before fix: false (bug)
// After fix: true (correct)
leftOnly.GetBorderLeft()
```

## Test plan

- [x] Added `TestBorderStyleDefaultSides` covering the exact reproducer from the issue
- [x] Added edge case test: `BorderLeft(false)` before `BorderStyle()` preserves the explicit setting
- [x] All existing tests pass (`go test ./...`)