### PR TITLE
Inline: replace newlines with a space, not empty string

### DIFF
--- a/style.go
+++ b/style.go
@@ -399,9 +399,11 @@ func (s Style) Render(strs ...string) string {
 	// carriage returns can cause strange behaviour when rendering.
 	str = strings.ReplaceAll(str, "\r\n", "\n")
 
-	// Strip newlines in single line mode
+	// Strip newlines in single line mode. Replace with a space so that
+	// words on separate lines stay separated when collapsed onto one
+	// line (e.g. "hello\nworld" -> "hello world", not "helloworld").
 	if inline {
-		str = strings.ReplaceAll(str, "\n", "")
+		str = strings.ReplaceAll(str, "\n", " ")
 	}
 
 	// Include borders in block size.

--- a/style_test.go
+++ b/style_test.go
@@ -517,6 +517,31 @@ func requireNotEqual(tb testing.TB, a, b any) {
 	}
 }
 
+func TestInlinePreservesWordBoundaries(t *testing.T) {
+	// Inline collapses multi-line input onto a single line. Newlines
+	// should be replaced with a space so adjacent words don't end up
+	// jammed together. Regression for #116.
+	testStyle := NewStyle().Inline(true)
+	got := testStyle.Render("hello\nworld")
+	want := "hello world"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+
+	// \r\n normalizes to \n first, then becomes a single space.
+	got = testStyle.Render("hello\r\nworld")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+
+	// Multiple consecutive newlines each become their own space.
+	got = testStyle.Render("a\n\nb")
+	want = "a  b"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 func TestCarriageReturnInRender(t *testing.T) {
 	out := fmt.Sprintf("%s\r\n%s\r\n", "Super duper california oranges", "Hello world")
 	testStyle := NewStyle().


### PR DESCRIPTION
## Summary

`Style.Inline(true)` currently collapses multi-line input by stripping newlines entirely:

```go
Style.Inline(true).Render("hello\nworld") // → "helloworld"
```

…which jams words together. Replacing with a single space preserves word boundaries so the rendered text reads naturally when collapsed to one line:

```go
Style.Inline(true).Render("hello\nworld") // → "hello world"
```

## Change

```diff
-    // Strip newlines in single line mode
+    // Strip newlines in single line mode. Replace with a space so that
+    // words on separate lines stay separated when collapsed onto one
+    // line (e.g. "hello\nworld" -> "hello world", not "helloworld").
     if inline {
-        str = strings.ReplaceAll(str, "\n", "")
+        str = strings.ReplaceAll(str, "\n", " ")
     }
```

## Invariants preserved

- The Inline docstring says "makes rendering output one line" — still true. `\n` is the sole multi-line marker after the `\r\n` normalization on the preceding line, and no line breaks are reintroduced downstream (the `strings.SplitSeq(str, "\n")` loop then yields exactly one line).
- Short-circuit paths that depend on `!inline` (padding, margins, wrapping, borders) are unchanged.

## Tests

Added `TestInlinePreservesWordBoundaries` in `style_test.go` covering:

1. `"hello\nworld"` → `"hello world"`
2. `"hello\r\nworld"` → `"hello world"` (normalized through the `\r\n → \n` step first)
3. `"a\n\nb"` → `"a  b"` (each `\n` becomes its own space)

Note: Go isn't installed in my local environment, so I wasn't able to run `go test ./...` before pushing. The fix is a one-character change to a well-scoped branch; happy to iterate if the test cases need adjustment after CI runs.

Fixes #116