### PR TITLE
fix(style): replace newlines with spaces in Inline mode

### DIFF
--- a/style.go
+++ b/style.go
@@ -399,9 +399,10 @@ func (s Style) Render(strs ...string) string {
 	// carriage returns can cause strange behaviour when rendering.
 	str = strings.ReplaceAll(str, "\r\n", "\n")
 
-	// Strip newlines in single line mode
+	// Replace newlines with spaces in single line mode so words from
+	// separate lines don't get concatenated.
 	if inline {
-		str = strings.ReplaceAll(str, "\n", "")
+		str = strings.ReplaceAll(str, "\n", " ")
 	}
 
 	// Include borders in block size.

--- a/style_test.go
+++ b/style_test.go
@@ -530,6 +530,14 @@ func TestCarriageReturnInRender(t *testing.T) {
 	}
 }
 
+func TestInlineReplacesNewlinesWithSpaces(t *testing.T) {
+	got := NewStyle().Inline(true).Render("hello\nworld")
+	want := "hello world"
+	if got != want {
+		t.Fatalf("Inline should replace newlines with spaces.\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
 func TestWidth(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
Closes #116

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
charmbracelet/lipgloss

## Issue
https://github.com/charmbracelet/lipgloss/issues/116

## Root cause
In `style.go`, the `Render` function's inline branch stripped newlines entirely
via `strings.ReplaceAll(str, "\n", "")`. Inputs like `"hello\nworld"` therefore
collapsed into `"helloworld"` with no word boundary.

## Fix
Replace `"\n"` with `" "` (a single space) instead of an empty string when
inline mode is enabled, preserving the word boundary between lines.

## Regression test
`style_test.go` :: `TestInlineReplacesNewlinesWithSpaces` — asserts that
`NewStyle().Inline(true).Render("hello\nworld")` returns `"hello world"`.

## Risk
low

## Verification
Ran `go test .` — all root-package tests pass, including the new regression
test and existing inline-related tests.
