### PR TITLE
Fix infinite loop in renderHorizontalEdge with zero-width border characters 

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -512,7 +512,11 @@ func renderHorizontalEdge(left, middle, right string, width int) string {
 	for i := 0; i < width-leftWidth-rightWidth; {
 		r := runes[j]
 		out.WriteRune(r)
-		i += ansi.StringWidth(string(r))
+		runeWidth := ansi.StringWidth(string(r))
+		if runeWidth < 1 {
+			runeWidth = 1
+		}
+		i += runeWidth
 		j++
 		if j >= len(runes) {
 			j = 0


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

When you use a zero-width character (like a zero-width space `U+200B`) as a border character in __lipgloss__, the rendering hangs forever. 
The code that draws horizontal borders loops until it fills the required width, but zero-width characters don't add any width, so the loop never finishes.                                                    
                                                                                                                                                                                                                                                                                                                                                     The funny thing is this was already fixed in another part of the codebase (`whitespace.go`) where the same loop pattern exists. The width of each character is clamped to at least 1 so the loop always makes progress. The border code just never got the same treatment.                                                                     

```sh
$ go version

go version go1.26.2 linux/amd64
```

```
$ go env GOOS GOARCH

linux
amd64
```

```
$ uname -r

6.17.0-22-generic
```

Testing snippet:
```go
package lipgloss

import (
    "testing"
)

// Run with: go test -run TestZeroWidthBorderCharInfiniteLoop -timeout 5s
func TestZeroWidthBorderCharInfiniteLoop(t *testing.T) {
    zeroWidthBorder := Border{
        Top:         "\u200b",
        Bottom:      "\u200b",
        Left:        "|",
        Right:       "|",
        TopLeft:     "+",
        TopRight:    "+",
        BottomLeft:  "+",
        BottomRight: "+",
    }

    NewStyle().
        Border(zeroWidthBorder).
        Width(10).
        Render("hello")
}
```
