### PR TITLE
fix: GetBorder* bool getters return true when only BorderStyle is set

### DIFF
--- a/get.go
+++ b/get.go
@@ -234,7 +234,13 @@ func (s Style) GetVerticalMargins() int {
 // top, right, bottom, and left in that order. If no value is set for the
 // border style, Border{} is returned. For all other unset values false is
 // returned.
+//
+// If a border style is set but no sides are explicitly toggled, all four sides
+// are reported as true, matching the rendering behavior.
 func (s Style) GetBorder() (b Border, top, right, bottom, left bool) {
+	if s.isBorderStyleSetWithoutSides() {
+		return s.getBorderStyle(), true, true, true, true
+	}
 	return s.getBorderStyle(),
 		s.getAsBool(borderTopKey, false),
 		s.getAsBool(borderRightKey, false),
@@ -249,26 +255,42 @@ func (s Style) GetBorderStyle() Border {
 }
 
 // GetBorderTop returns the style's top border setting. If no value is set
-// false is returned.
+// false is returned. If a border style is set but no sides are explicitly
+// toggled, this returns true to match the rendering behavior.
 func (s Style) GetBorderTop() bool {
+	if s.isBorderStyleSetWithoutSides() {
+		return true
+	}
 	return s.getAsBool(borderTopKey, false)
 }
 
 // GetBorderRight returns the style's right border setting. If no value is set
-// false is returned.
+// false is returned. If a border style is set but no sides are explicitly
+// toggled, this returns true to match the rendering behavior.
 func (s Style) GetBorderRight() bool {
+	if s.isBorderStyleSetWithoutSides() {
+		return true
+	}
 	return s.getAsBool(borderRightKey, false)
 }
 
 // GetBorderBottom returns the style's bottom border setting. If no value is
-// set false is returned.
+// set false is returned. If a border style is set but no sides are explicitly
+// toggled, this returns true to match the rendering behavior.
 func (s Style) GetBorderBottom() bool {
+	if s.isBorderStyleSetWithoutSides() {
+		return true
+	}
 	return s.getAsBool(borderBottomKey, false)
 }
 
 // GetBorderLeft returns the style's left border setting. If no value is
-// set false is returned.
+// set false is returned. If a border style is set but no sides are explicitly
+// toggled, this returns true to match the rendering behavior.
 func (s Style) GetBorderLeft() bool {
+	if s.isBorderStyleSetWithoutSides() {
+		return true
+	}
 	return s.getAsBool(borderLeftKey, false)
 }
 

--- a/style_test.go
+++ b/style_test.go
@@ -352,6 +352,10 @@ func TestStyleUnset(t *testing.T) {
 
 	requireTrue(t, s.GetBorderLeft())
 	s = s.UnsetBorderLeft()
+	// At this point every side is unset but the border style is still set,
+	// which means it renders on all sides by default. Clear the style too so
+	// the getter reflects an actually empty border.
+	s = s.UnsetBorderStyle()
 	requireFalse(t, s.GetBorderLeft())
 
 	// tab width
@@ -359,6 +363,42 @@ func TestStyleUnset(t *testing.T) {
 	requireEqual(t, s.GetTabWidth(), 2)
 	s = s.UnsetTabWidth()
 	requireNotEqual(t, s.GetTabWidth(), 4)
+}
+
+func TestGetBorderWithoutSides(t *testing.T) {
+	t.Parallel()
+
+	// When BorderStyle is called without specifying sides, all four sides are
+	// rendered. The bool and size getters should agree with that.
+	s := NewStyle().BorderStyle(NormalBorder())
+	requireTrue(t, s.GetBorderTop())
+	requireTrue(t, s.GetBorderRight())
+	requireTrue(t, s.GetBorderBottom())
+	requireTrue(t, s.GetBorderLeft())
+	requireEqual(t, 1, s.GetBorderTopSize())
+	requireEqual(t, 1, s.GetBorderRightSize())
+	requireEqual(t, 1, s.GetBorderBottomSize())
+	requireEqual(t, 1, s.GetBorderLeftSize())
+
+	_, top, right, bottom, left := s.GetBorder()
+	requireTrue(t, top)
+	requireTrue(t, right)
+	requireTrue(t, bottom)
+	requireTrue(t, left)
+
+	// A style with no border at all should still report false everywhere.
+	empty := NewStyle()
+	requireFalse(t, empty.GetBorderTop())
+	requireFalse(t, empty.GetBorderRight())
+	requireFalse(t, empty.GetBorderBottom())
+	requireFalse(t, empty.GetBorderLeft())
+
+	// Explicit side toggles must win over the default-on behavior.
+	partial := NewStyle().Border(NormalBorder(), false, true, true, true)
+	requireFalse(t, partial.GetBorderTop())
+	requireTrue(t, partial.GetBorderRight())
+	requireTrue(t, partial.GetBorderBottom())
+	requireTrue(t, partial.GetBorderLeft())
 }
 
 func TestStyleValue(t *testing.T) {


### PR DESCRIPTION
The size getters (`GetBorderTopSize` and friends) and the renderer both treat a style that has `BorderStyle` set but no explicit sides as "border on all four sides," ever since #411 / the fix in 9ae54a0. The bool getters (`GetBorderTop`, `GetBorderRight`, `GetBorderBottom`, `GetBorderLeft`, and `GetBorder`) never got that treatment though, so they still report false in that case.

That makes things like this misleading:

```go
s := lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder())
s.GetBorderTopSize() // 1
s.GetBorderTop()     // false  <-- but rendering shows a top border
```

This adds the same `isBorderStyleSetWithoutSides()` check to the bool getters so all the border accessors agree with each other and with what actually renders. Should also help with #366 and #522 since they're both flavors of the same inconsistency.

One existing assertion in `TestStyleUnset` was relying on the old behavior: it unset all four sides and expected `GetBorderLeft()` to be false, but the border style was still set so a border still renders on all sides. I added an `UnsetBorderStyle()` call to clear that too, which matches the real "no border" state.

## How to test

```
go test ./...
```

The new test is `TestGetBorderWithoutSides`.