### PR TITLE
fix(tree): stop swapping Offset start and end

### DIFF
--- a/tree/tree.go
+++ b/tree/tree.go
@@ -118,19 +118,24 @@ func (t *Tree) Hide(hide bool) *Tree {
 // SetHidden hides a Tree node.
 func (t *Tree) SetHidden(hidden bool) { t.Hide(hidden) }
 
-// Offset sets the Tree children offsets.
+// Offset sets the Tree children offsets. start is the number of children to
+// skip from the beginning and end is the number of children to skip from the
+// end, so Offset(2, 1) on a five-child tree renders children at indices 2 and
+// 3. See charmbracelet/lipgloss#535.
 func (t *Tree) Offset(start, end int) *Tree {
-	if start > end {
-		_start := start
-		start = end
-		end = _start
-	}
-
 	if start < 0 {
 		start = 0
 	}
-	if end < 0 || end > t.children.Length() {
-		end = t.children.Length()
+	if end < 0 {
+		end = 0
+	}
+
+	length := t.children.Length()
+	if start > length {
+		start = length
+	}
+	if end > length {
+		end = length
 	}
 
 	t.offset[0] = start

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -1,6 +1,7 @@
 package tree_test
 
 import (
+	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
@@ -499,4 +500,38 @@ func TestTypes(t *testing.T) {
 		Child([]string{"Qux", "Quux", "Quuux"})
 
 	golden.RequireEqual(t, []byte(tree.String()))
+}
+
+func TestTreeOffsetAsymmetric(t *testing.T) {
+	// Regression test for #535: Offset(start, end) treats start as "skip N from
+	// the beginning" and end as "skip N from the end". The earlier
+	// implementation swapped them when start > end, which made Offset(2, 1)
+	// behave like Offset(1, 2) — the duckduckgoose example rendered only the
+	// first two Ducks instead of the third Duck and the Goose.
+	tr := tree.New().Child("Duck", "Duck", "Duck", "Goose", "Duck").Offset(2, 1)
+
+	got := tr.String()
+	wantHas := []string{"Duck", "Goose"}
+	for _, w := range wantHas {
+		if !strings.Contains(got, w) {
+			t.Errorf("Offset(2,1) output should contain %q, got:\n%s", w, got)
+		}
+	}
+
+	// The first two Ducks and the final Duck should be hidden.
+	duckCount := strings.Count(got, "Duck")
+	if duckCount != 1 {
+		t.Errorf("Offset(2,1) should leave exactly one Duck visible (index 2), got %d:\n%s", duckCount, got)
+	}
+}
+
+func TestTreeOffsetClampsNegative(t *testing.T) {
+	// Offset(-5, -5) should be equivalent to Offset(0, 0): no skipping.
+	tr := tree.New().Child("a", "b", "c").Offset(-5, -5)
+	got := tr.String()
+	for _, want := range []string{"a", "b", "c"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Offset(-5,-5) should still show %q, got:\n%s", want, got)
+		}
+	}
 }


### PR DESCRIPTION
Closes #535.

\`Tree.Offset(start, end)\` is documented (via \`list.Offset\`) such that \`start\` counts from the beginning and \`end\` counts from the end:

> Offset(1, -1) on [A, B, C, D] shows [B, C, D]

The implementation swapped \`start\` and \`end\` whenever \`start > end\`, so \`Offset(2, 1)\` on the duckduckgoose example ([\"Duck\", \"Duck\", \"Duck\", \"Goose\", \"Duck\"]) ended up acting like \`Offset(1, 2)\` and rendered the first two Ducks instead of the third Duck plus the Goose. The two arguments aren't interchangeable coordinates, so the swap was wrong.

While I was in there I also tightened the bounds: \`start\` and \`end\` are both clamped to \`[0, length]\`, and \`end = -1\` (the \"skip nothing from end\" idiom in the docs example) is normalized to \`0\` instead of clamping to \`length\` (which previously made the loop in render iterate over zero elements).

## Test plan

\`\`\`
go test ./...
\`\`\`

Added two new unit tests in \`tree/tree_test.go\`:

- \`TestTreeOffsetAsymmetric\` — the case from the issue, \`Offset(2, 1)\` on five children leaves exactly one Duck and the Goose visible.
- \`TestTreeOffsetClampsNegative\` — \`Offset(-5, -5)\` is a no-op and the full child list still renders.