### PR TITLE
feat: add GetMarginBackground getter method

### DIFF
--- a/get.go
+++ b/get.go
@@ -218,6 +218,12 @@ func (s Style) GetMarginChar() rune {
 	return char
 }
 
+// GetMarginBackground returns the style's margin background color. If no value
+// is set nil is returned.
+func (s Style) GetMarginBackground() color.Color {
+	return s.getAsColor(marginBackgroundKey)
+}
+
 // GetHorizontalMargins returns the style's left and right margins. Unset
 // values are measured as 0.
 func (s Style) GetHorizontalMargins() int {

--- a/style_test.go
+++ b/style_test.go
@@ -314,6 +314,12 @@ func TestStyleUnset(t *testing.T) {
 	s = s.UnsetMarginLeft()
 	requireEqual(t, 0, s.GetMarginLeft())
 
+	// margin background
+	s = NewStyle().MarginBackground(col)
+	requireEqual(t, col, s.GetMarginBackground())
+	s = s.UnsetMarginBackground()
+	requireNotEqual(t, col, s.GetMarginBackground())
+
 	// padding
 	s = NewStyle().Padding(1, 2, 3, 4).PaddingChar('x')
 	requireEqual(t, 1, s.GetPaddingTop())


### PR DESCRIPTION
I noticed that while lipgloss has `MarginBackground()` to set the margin background color and `UnsetMarginBackground()` to clear it, there's no corresponding getter to retrieve the value.

This adds `GetMarginBackground()` which returns the style's margin background color (or nil if not set). The implementation follows the same pattern as other color getters in the codebase.

Addresses the remaining gap from #111.
