### PR TITLE
feat: add UnsetBorder method to clear all border properties

### DIFF
--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,5 @@
+I noticed that while lipgloss has `MarginBackground()` to set the margin background color and `UnsetMarginBackground()` to clear it, there's no corresponding getter to retrieve the value.
+
+This adds `GetMarginBackground()` which returns the style's margin background color (or nil if not set). The implementation follows the same pattern as other color getters in the codebase.
+
+Addresses the remaining gap from #111.

--- a/style_test.go
+++ b/style_test.go
@@ -354,6 +354,19 @@ func TestStyleUnset(t *testing.T) {
 	s = s.UnsetBorderLeft()
 	requireFalse(t, s.GetBorderLeft())
 
+	// unset all border properties at once
+	s = NewStyle().Border(normalBorder, true, true, true, true).
+		BorderForeground(col).BorderBackground(col)
+	requireTrue(t, s.GetBorderTop())
+	requireTrue(t, s.GetBorderRight())
+	requireTrue(t, s.GetBorderBottom())
+	requireTrue(t, s.GetBorderLeft())
+	s = s.UnsetBorder()
+	requireFalse(t, s.GetBorderTop())
+	requireFalse(t, s.GetBorderRight())
+	requireFalse(t, s.GetBorderBottom())
+	requireFalse(t, s.GetBorderLeft())
+
 	// tab width
 	s = NewStyle().TabWidth(2)
 	requireEqual(t, s.GetTabWidth(), 2)

--- a/unset.go
+++ b/unset.go
@@ -176,6 +176,26 @@ func (s Style) UnsetMarginBackground() Style {
 	return s
 }
 
+// UnsetBorder removes all border style rules.
+func (s Style) UnsetBorder() Style {
+	s.unset(borderStyleKey)
+	s.unset(borderTopKey)
+	s.unset(borderRightKey)
+	s.unset(borderBottomKey)
+	s.unset(borderLeftKey)
+	s.unset(borderTopForegroundKey)
+	s.unset(borderRightForegroundKey)
+	s.unset(borderBottomForegroundKey)
+	s.unset(borderLeftForegroundKey)
+	s.unset(borderForegroundBlendKey)
+	s.unset(borderForegroundBlendOffsetKey)
+	s.unset(borderTopBackgroundKey)
+	s.unset(borderRightBackgroundKey)
+	s.unset(borderBottomBackgroundKey)
+	s.unset(borderLeftBackgroundKey)
+	return s
+}
+
 // UnsetBorderStyle removes the border style rule, if set.
 func (s Style) UnsetBorderStyle() Style {
 	s.unset(borderStyleKey)


### PR DESCRIPTION
﻿Lipgloss has `UnsetPadding()` to clear all padding rules and `UnsetMargins()` to clear all margin rules in one call. This adds the equivalent `UnsetBorder()` method to clear all border-related style rules at once.

The method unsets the border style, individual sides (top/right/bottom/left), foreground colors, background colors, and blend settings.

Addresses the remaining portion of #111.
