### PR TITLE
collapse newlines to spaces in inline mode

### DIFF
--- a/style.go
+++ b/style.go
@@ -399,9 +399,11 @@ func (s Style) Render(strs ...string) string {
 	// carriage returns can cause strange behaviour when rendering.
 	str = strings.ReplaceAll(str, "\r\n", "\n")
 
-	// Strip newlines in single line mode
+	// Collapse newlines to spaces in single line mode so words from
+	// adjacent lines stay separated. Stripping them outright (the
+	// previous behavior) ran "hello\nworld" together as "helloworld".
 	if inline {
-		str = strings.ReplaceAll(str, "\n", "")
+		str = strings.ReplaceAll(str, "\n", " ")
 	}
 
 	// Include borders in block size.

--- a/style_test.go
+++ b/style_test.go
@@ -421,6 +421,15 @@ func TestCustomPaddingChar(t *testing.T) {
 	requireEqual(t, "xxxTESTxxx", s.Render("TEST"))
 }
 
+// Regression for #116. Inline used to drop \n entirely, so a multi-line
+// input was rendered as a single run-on word: "hello\nworld" became
+// "helloworld". Newlines now collapse to spaces so the words stay
+// separated.
+func TestInlineCollapsesNewlinesToSpaces(t *testing.T) {
+	s := NewStyle().Inline(true)
+	requireEqual(t, "hello world", s.Render("hello\nworld"))
+}
+
 func TestTabConversion(t *testing.T) {
 	s := NewStyle()
 	requireEqual(t, "[    ]", s.Render("[\t]"))


### PR DESCRIPTION
Closes #116.

\`Inline\` used to drop \`\\n\` outright, so rendering \`\"hello\\nworld\"\` produced \`\"helloworld\"\` with no separator. Replacing the newline with a space keeps the words apart, which is what users expect when collapsing a paragraph onto one line.

Added a small regression test in \`TestInlineCollapsesNewlinesToSpaces\`.