### PR TITLE
fix table size to correctly account for border

### DIFF
--- a/table/resizing.go
+++ b/table/resizing.go
@@ -188,7 +188,7 @@ func newResizer(tableWidth, tableHeight int, headers []string, rows [][]string) 
 
 // optimizedWidths returns the optimized column widths and row heights.
 func (r *resizer) optimizedWidths() (colWidths, rowHeights []int) {
-	if r.maxTotal() <= r.tableWidth {
+	if r.maxTotal()+r.totalHorizontalBorder() <= r.tableWidth {
 		return r.expandTableWidth(), r.rowHeights
 	}
 	return r.shrinkTableWidth(), r.rowHeights


### PR DESCRIPTION
# `Table.Width()` overflow in the border dead zone

*Disclaimer* I am new to go, this was found and fixed agent assisted but i took the time to understand and test. 

## My use case

I am using in my application something like:

```go
t := table.New().
    Border(lipgloss.RoundedBorder()).
    Headers(headers...).
    Rows(rows...).
    StyleFunc(func(row, col int) lipgloss.Style {
        return lipgloss.NewStyle().Padding(0, 1)
    })

if naturalWidth(headers, rows) > termW {
    t = t.Width(termW).Wrap(true)
}
fmt.Println(t)
```

Contract expectation: `Width(termW).Wrap(true)` produces a rendered table whose
width is `≤ termW`. The widest column wraps onto extra lines as needed.

## The bug

For a narrow range of terminal widths, the rendered table is wider than the
value passed to `Width()`. The terminal clips the right edge:

see screenshot with the bug ->

<img width="1292" height="167" alt="screenshot-2026-05-17_11-09-09" src="https://github.com/user-attachments/assets/05df2dbf-8b82-465d-8048-865c8412d1c5" />

My expectation (and how it renders after the fix) is -> 
<img width="1289" height="185" alt="screenshot-2026-05-17_11-12-27" src="https://github.com/user-attachments/assets/51a239c6-4e6c-4a73-b8d7-e196570d063b" />

I am using ghostty in omarchy, and the terminal was a pane with a specific size (I don't know if that matter) for some sizes it works fine, but other has the issue.

## Repro

```go
package main

import (
    "fmt"
    "charm.land/lipgloss/v2"
    "charm.land/lipgloss/v2/table"
)

func main() {
    headers := []string{"ID", "SECTION", "SCHEDULE", "WARNINGS", "DESCRIPTION"}
    rows := [][]string{
        {"daily_planner", "Assistant", "-", "-",
            "What did I do yesterday. What should i Do today"},
        {"ping", "Agents", "mon,tue,wed,thu,fri,sat,sun 04:00", "-", "test ping"},
    }
    // Natural rendered width (including borders) = 126.
    // Content+padding total (excluding borders)  = 120.
    // Border characters                          = 6 (cols+1 with column separators).
    //
    // For Width(W) with W in [120 .. 125] the table renders at 126.
    // Only W ≤ 119 actually shrinks.
    for _, W := range []int{125, 122, 120, 119} {
        t := table.New().
            Border(lipgloss.RoundedBorder()).
            Headers(headers...).
            Rows(rows...).
            StyleFunc(func(_, _ int) lipgloss.Style {
                return lipgloss.NewStyle().Padding(0, 1)
            }).
            Width(W).Wrap(true)
        fmt.Printf("Width(%d) → rendered %d\n", W, lipgloss.Width(t.String()))
    }
}
```

Output:

```
Width(125) → rendered 126   ← overflows by 1
Width(122) → rendered 126   ← overflows by 4
Width(120) → rendered 126   ← overflows by 6
Width(119) → rendered 119   ← correct
```

The "dead zone" is `(maxTotal, maxTotal + borders]` where `maxTotal` is the
sum of content widths + padding (no borders).

## Why it happens

`table/resizing.go`:

```go
// optimizedWidths returns the optimized column widths and row heights.
func (r *resizer) optimizedWidths() (colWidths, rowHeights []int) {
    if r.maxTotal() <= r.tableWidth {        // ← compares without borders
        return r.expandTableWidth(), r.rowHeights
    }
    return r.shrinkTableWidth(), r.rowHeights
}
```

`maxTotal()` returns column content + padding only. Borders are not counted.

When the caller passes `Width(W)` with `maxTotal ≤ W < maxTotal + borders`:

1. The branch picks `expandTableWidth` (because `maxTotal ≤ W`).
2. `expandTableWidth` immediately exits — its loop guard is
   `sum(colWidths) + totalHorizontalBorder() >= tableWidth`, and that is
   already true since `sum + borders > W`.
3. No column is shrunk. The table renders at its natural width — wider than
   `W`.

The shrink path would have handled this correctly: its loop guard is
`sum + border <= tableWidth`, which would have shrunk one (or more) columns
to bring the rendered width down to `W`.

## Fix

One line. Compare the **rendered** width (content + padding + borders)
against the caller-supplied target:

```go
func (r *resizer) optimizedWidths() (colWidths, rowHeights []int) {
    if r.maxTotal()+r.totalHorizontalBorder() <= r.tableWidth {
        return r.expandTableWidth(), r.rowHeights
    }
    return r.shrinkTableWidth(), r.rowHeights
}
```

- `tableWidth` is the **rendered-width** target the caller asked for.
- `maxTotal()` is **not** the rendered width — it omits borders.
- The expand/shrink decision should branch on whether the rendered
  natural width fits in `tableWidth`, not on a partial measurement.

After the fix, the dead zone is funnelled into `shrinkTableWidth`, whose
loop accounts for borders and produces a table of exactly `tableWidth`
characters. The expand path is unaffected for tables whose natural rendered
width is strictly less than `tableWidth` — they still expand to fill.