### PR TITLE
fix(table): account for column borders in width budget

### DIFF
--- a/table/resizing.go
+++ b/table/resizing.go
@@ -188,7 +188,7 @@ func newResizer(tableWidth, tableHeight int, headers []string, rows [][]string) 
 
 // optimizedWidths returns the optimized column widths and row heights.
 func (r *resizer) optimizedWidths() (colWidths, rowHeights []int) {
-	if r.maxTotal() <= r.tableWidth {
+	if r.maxTotal()+r.totalHorizontalBorder() <= r.tableWidth {
 		return r.expandTableWidth(), r.rowHeights
 	}
 	return r.shrinkTableWidth(), r.rowHeights

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -489,6 +489,25 @@ func TestTableWidthShrink(t *testing.T) {
 	})
 }
 
+func TestTableWidthIncludesColumnBorders(t *testing.T) {
+	t.Parallel()
+
+	rows := [][]string{
+		{"AB", "CD"},
+		{"12", "34"},
+	}
+
+	table := New().
+		Width(10).
+		Border(lipgloss.NormalBorder()).
+		Headers("AB", "CD").
+		Rows(rows...)
+
+	if got := lipgloss.Width(table.String()); got > 10 {
+		t.Fatalf("expected rendered width <= 10, got %d:\n%s", got, table.String())
+	}
+}
+
 func TestTableWidthSmartCrop(t *testing.T) {
 	rows := [][]string{
 		{"Kini", "40", "New York"},


### PR DESCRIPTION
## Summary

Fixes #574.

Table resize now includes vertical column borders when deciding whether content exceeds the configured width.

## Test plan

- [x] `go test ./table/... -run TestTableWidthIncludesColumnBorders -v`