### PR TITLE
fix: avoid trailing padding on multiline left-aligned Render

### DIFF
--- a/style.go
+++ b/style.go
@@ -482,13 +482,10 @@ func (s Style) Render(strs ...string) string {
 		str = alignTextVertical(str, verticalAlign, height, nil)
 	}
 
-	// Set alignment. This will also pad short lines with spaces so that all
-	// lines are the same length, so we run it under a few different conditions
-	// beyond alignment.
+	// Set alignment. This also pads short lines to the widest line when a block
+	// width is set or when center/right alignment needs equal line widths.
 	{
-		numLines := strings.Count(str, "\n")
-
-		if numLines != 0 || width != 0 {
+		if width > 0 || horizontalAlign != Left {
 			var st *ansi.Style
 			if colorWhitespace || styleWhitespace {
 				st = &teWhitespace

--- a/style_test.go
+++ b/style_test.go
@@ -517,6 +517,23 @@ func requireNotEqual(tb testing.TB, a, b any) {
 	}
 }
 
+func TestMultilineRenderLeftAlignNoTrailingPadding(t *testing.T) {
+	style := NewStyle().Foreground(Color("#58A6FF"))
+	long := strings.Repeat("a", 80)
+	short := "short"
+	rendered := style.Render(long + "\n" + short)
+
+	lines := strings.Split(rendered, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d", len(lines))
+	}
+
+	shortLine := lines[1]
+	if strings.TrimRight(shortLine, " ") != shortLine {
+		t.Fatalf("short line has trailing whitespace padding: %q", shortLine)
+	}
+}
+
 func TestCarriageReturnInRender(t *testing.T) {
 	out := fmt.Sprintf("%s\r\n%s\r\n", "Super duper california oranges", "Hello world")
 	testStyle := NewStyle().


### PR DESCRIPTION
## Summary

Fixes #577.

`Style.Render` always called `alignTextHorizontal` for multiline strings, which padded every shorter line with spaces up to the widest line. That is desirable for explicit `Width` or center/right alignment, but left-aligned prose (e.g. colored body text in a viewport) picked up large trailing whitespace when piped to stdout or `less`.

## Changes

Only run horizontal alignment normalization when `width > 0` or horizontal alignment is not `Left`.

## Test plan

- [x] `go test ./...`
- [x] `TestMultilineRenderLeftAlignNoTrailingPadding`