### PR TITLE
fix: default unset border sides to on so BorderTop(false) doesn't take the whole border with it

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -333,13 +333,22 @@ func (s Style) applyBorder(str string) string {
 		hasLeft   = s.getAsBool(borderLeftKey, false)
 	)
 
-	// If a border is set and no sides have been specifically turned on or off
-	// render borders on all sides.
-	if s.isBorderStyleSetWithoutSides() {
-		hasTop = true
-		hasRight = true
-		hasBottom = true
-		hasLeft = true
+	// If a border style is set, any side the caller didn't touch defaults to
+	// on. That way BorderTop(false) on its own leaves the other three sides
+	// rendered, instead of silently turning the whole border off.
+	if border != noBorder {
+		if !s.isSet(borderTopKey) {
+			hasTop = true
+		}
+		if !s.isSet(borderRightKey) {
+			hasRight = true
+		}
+		if !s.isSet(borderBottomKey) {
+			hasBottom = true
+		}
+		if !s.isSet(borderLeftKey) {
+			hasLeft = true
+		}
 	}
 
 	// If no border is set or all borders are been disabled, abort.

--- a/borders_test.go
+++ b/borders_test.go
@@ -208,6 +208,29 @@ func BenchmarkMaxRuneWidth(b *testing.B) {
 	}
 }
 
+func TestBorderPartialSidesDefaultOn(t *testing.T) {
+	// Regression for #194: turning some sides off shouldn't take the
+	// untouched sides down with them.
+	s := NewStyle().
+		Border(NormalBorder()).
+		BorderTop(false).
+		BorderRight(false).
+		BorderBottom(false)
+
+	got := s.Render("x")
+	want := "│x"
+	if got != want {
+		t.Errorf("expected only the left border to render; got %q, want %q", got, want)
+	}
+
+	if s.GetBorderLeftSize() != 1 {
+		t.Errorf("GetBorderLeftSize: got %d, want 1", s.GetBorderLeftSize())
+	}
+	if s.GetBorderTopSize() != 0 {
+		t.Errorf("GetBorderTopSize: got %d, want 0", s.GetBorderTopSize())
+	}
+}
+
 func maxRuneWidthOld(str string) int {
 	var width int
 

--- a/get.go
+++ b/get.go
@@ -345,10 +345,7 @@ func (s Style) GetBorderTopWidth() int {
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the top edge, 0 is returned.
 func (s Style) GetBorderTopSize() int {
-	if s.isBorderStyleSetWithoutSides() {
-		return 1
-	}
-	if !s.getAsBool(borderTopKey, false) {
+	if !s.borderSideRendered(borderTopKey) {
 		return 0
 	}
 	return s.getBorderStyle().GetTopSize()
@@ -358,10 +355,7 @@ func (s Style) GetBorderTopSize() int {
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the left edge, 0 is returned.
 func (s Style) GetBorderLeftSize() int {
-	if s.isBorderStyleSetWithoutSides() {
-		return 1
-	}
-	if !s.getAsBool(borderLeftKey, false) {
+	if !s.borderSideRendered(borderLeftKey) {
 		return 0
 	}
 	return s.getBorderStyle().GetLeftSize()
@@ -371,10 +365,7 @@ func (s Style) GetBorderLeftSize() int {
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the left edge, 0 is returned.
 func (s Style) GetBorderBottomSize() int {
-	if s.isBorderStyleSetWithoutSides() {
-		return 1
-	}
-	if !s.getAsBool(borderBottomKey, false) {
+	if !s.borderSideRendered(borderBottomKey) {
 		return 0
 	}
 	return s.getBorderStyle().GetBottomSize()
@@ -384,13 +375,23 @@ func (s Style) GetBorderBottomSize() int {
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the right edge, 0 is returned.
 func (s Style) GetBorderRightSize() int {
-	if s.isBorderStyleSetWithoutSides() {
-		return 1
-	}
-	if !s.getAsBool(borderRightKey, false) {
+	if !s.borderSideRendered(borderRightKey) {
 		return 0
 	}
 	return s.getBorderStyle().GetRightSize()
+}
+
+// borderSideRendered reports whether the given border side should render in
+// the final output, matching applyBorder: a side defaults to on whenever a
+// border style is set and the caller hasn't explicitly turned that side off.
+func (s Style) borderSideRendered(key propKey) bool {
+	if s.getBorderStyle() == noBorder {
+		return false
+	}
+	if !s.isSet(key) {
+		return true
+	}
+	return s.getAsBool(key, false)
 }
 
 // GetHorizontalBorderSize returns the width of the horizontal borders. If
@@ -640,16 +641,3 @@ func getLines(s string) (lines []string, widest int) {
 	return lines, widest
 }
 
-// isBorderStyleSetWithoutSides returns true if the border style is set but no
-// sides are set. This is used to determine if the border should be rendered by
-// default.
-func (s Style) isBorderStyleSetWithoutSides() bool {
-	var (
-		border    = s.getBorderStyle()
-		topSet    = s.isSet(borderTopKey)
-		rightSet  = s.isSet(borderRightKey)
-		bottomSet = s.isSet(borderBottomKey)
-		leftSet   = s.isSet(borderLeftKey)
-	)
-	return border != noBorder && !(topSet || rightSet || bottomSet || leftSet) //nolint:staticcheck
-}


### PR DESCRIPTION
Closes #194.

`applyBorder` only treated sides as defaulting-on if no side at all had been touched. Setting just `BorderTop(false)` flipped top off but left right/bottom/left as their false defaults, so the all-false guard returned the original string and the whole border vanished.

When a border style is set, sides the caller didn't touch now default to on. `GetBorderTopSize` etc. use the same rule so frame math stays in sync. Regression test added.