### PR TITLE
fix: unset underline style rule

### DIFF
--- a/style_test.go
+++ b/style_test.go
@@ -191,6 +191,18 @@ func TestStyleInherit(t *testing.T) {
 	requireNotEqual(t, s.GetPaddingBottom(), i.GetPaddingBottom())
 }
 
+func TestUnsetUnderlineAllowsInheritance(t *testing.T) {
+	t.Parallel()
+
+	parent := NewStyle().Underline(true)
+
+	explicitOff := NewStyle().Underline(false).Inherit(parent)
+	requireFalse(t, explicitOff.GetUnderline())
+
+	unset := NewStyle().Underline(true).UnsetUnderline().Inherit(parent)
+	requireTrue(t, unset.GetUnderline())
+}
+
 func TestStyleCopy(t *testing.T) {
 	t.Parallel()
 

--- a/unset.go
+++ b/unset.go
@@ -19,7 +19,9 @@ func (s Style) UnsetItalic() Style {
 
 // UnsetUnderline removes the underline style rule, if set.
 func (s Style) UnsetUnderline() Style {
-	return s.Underline(false)
+	s.unset(underlineKey)
+	s.ul = UnderlineNone
+	return s
 }
 
 // UnsetStrikethrough removes the strikethrough style rule, if set.


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## Summary

Fix `Style.UnsetUnderline()` so it actually removes the underline style rule instead of setting underline to `false`.

## Problem

`UnsetUnderline()` currently calls `Underline(false)`. That makes rendered text stop using underline, but internally it still leaves the underline property marked as explicitly set.

That matters when using `Inherit()`: inherited values are only copied when the child style has not already set that property.

Before this change, a style that called `UnsetUnderline()` could not inherit underline from a parent style.

## Example

```go
parent := lipgloss.NewStyle().Underline(true)

child := lipgloss.NewStyle().
    Underline(true).
    UnsetUnderline().
    Inherit(parent)
```
Expected: child inherits underline from parent.

Before this fix: child does not inherit underline, because UnsetUnderline() leaves an explicit "underline off" rule behind.

## Fix

UnsetUnderline() now clears the underline property directly and resets the stored underline value to UnderlineNone.

This keeps UnsetUnderline() consistent with other unset methods such as UnsetBold(), UnsetItalic(), and UnsetStrikethrough().

## Tests

Added a focused test covering the difference between:

- Underline(false): explicitly disables underline and blocks inheritance.
- UnsetUnderline(): removes the underline rule and allows inheritance.

## Validation
 ```sh
go test . -run 'TestUnsetUnderlineAllowsInheritance|TestStyleUnset|TestStyleInherit'
go test ./...
git diff --checkk
```