### PR TITLE
Preserve backgrounds after embedded ANSI resets

### DIFF
--- a/style.go
+++ b/style.go
@@ -194,6 +194,13 @@ type Style struct {
 	transform func(string) string
 }
 
+const (
+	ansiCSI         = "\x1b["
+	ansiSGRCommand  = 'm'
+	minCSIFinalByte = 0x40
+	maxCSIFinalByte = 0x7e
+)
+
 // joinString joins a list of strings into a single string separated with a
 // space.
 func joinString(strs ...string) string {
@@ -435,7 +442,7 @@ func (s Style) Render(strs ...string) string {
 					b.WriteString(te.Styled(string(r)))
 				}
 			} else {
-				b.WriteString(te.Styled(line))
+				b.WriteString(te.Styled(reapplyStyleAfterReset(line, te)))
 			}
 		}
 
@@ -523,6 +530,74 @@ func (s Style) Render(strs ...string) string {
 	}
 
 	return str
+}
+
+func reapplyStyleAfterReset(str string, style ansi.Style) string {
+	if len(style) == 0 || !strings.Contains(str, ansiCSI) {
+		return str
+	}
+
+	var b strings.Builder
+	styleSequence := style.String()
+	for len(str) > 0 {
+		idx := strings.Index(str, ansiCSI)
+		if idx == -1 {
+			b.WriteString(str)
+			break
+		}
+
+		b.WriteString(str[:idx])
+		str = str[idx:]
+
+		end := findCSIEnd(str)
+		if end == -1 {
+			b.WriteString(str)
+			break
+		}
+
+		sequence := str[:end+1]
+		b.WriteString(sequence)
+		str = str[end+1:]
+		if isStyleReset(sequence) && str != "" {
+			b.WriteString(styleSequence)
+		}
+	}
+
+	return b.String()
+}
+
+func findCSIEnd(str string) int {
+	for i := len(ansiCSI); i < len(str); i++ {
+		if str[i] >= minCSIFinalByte && str[i] <= maxCSIFinalByte {
+			return i
+		}
+	}
+	return -1
+}
+
+func isStyleReset(sequence string) bool {
+	if !strings.HasPrefix(sequence, ansiCSI) || sequence[len(sequence)-1] != ansiSGRCommand {
+		return false
+	}
+
+	params := sequence[len(ansiCSI) : len(sequence)-1]
+	if params == "" {
+		return true
+	}
+
+	for _, param := range strings.FieldsFunc(params, func(r rune) bool {
+		return r == ';' || r == ':'
+	}) {
+		if param == "" {
+			continue
+		}
+		for _, r := range param {
+			if r != '0' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (s Style) maybeConvertTabs(str string) string {

--- a/style_test.go
+++ b/style_test.go
@@ -141,6 +141,36 @@ func TestStyleRender(t *testing.T) {
 	}
 }
 
+func TestStyleRenderPreservesBackgroundAfterANSIReset(t *testing.T) {
+	t.Parallel()
+
+	style := NewStyle().Background(Color("22"))
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "explicit reset",
+			input:    "\x1b[32mname\x1b[0m: value",
+			expected: "\x1b[48;5;22m\x1b[32mname\x1b[0m\x1b[48;5;22m: value\x1b[m",
+		},
+		{
+			name:     "implicit reset",
+			input:    "\x1b[32mname\x1b[m: value",
+			expected: "\x1b[48;5;22m\x1b[32mname\x1b[m\x1b[48;5;22m: value\x1b[m",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := style.Render(tc.input); got != tc.expected {
+				t.Errorf("expected:\n`%q`\n\nActual output:\n`%q`\n\n", tc.expected, got)
+			}
+		})
+	}
+}
+
 func TestValueCopy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- keep an outer Lip Gloss style active after embedded ANSI SGR reset sequences
- preserve background styling when rendering highlighted text that contains token-level resets
- add regression coverage for explicit and implicit ANSI resets

Fixes #124

## Testing

- go test . -run TestStyleRenderPreservesBackgroundAfterANSIReset -count=1
- go test ./... -count=1
- go vet .
- git diff --check

Note: go vet ./... currently reports an existing issue in table/table_test.go:825 where a Table.String() result is unused; the changed package passes go vet .
