### PR TITLE
Fix order of calling w.Close in Wrap

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -13,8 +13,8 @@ func Wrap(s string, width int, breakpoints string) string {
 	var buf bytes.Buffer
 	s = ansi.Wrap(s, width, breakpoints)
 	w := NewWrapWriter(&buf)
-	defer w.Close() //nolint:errcheck
 	_, _ = io.WriteString(w, s)
+	_ = w.Close()
 	return buf.String()
 }
 


### PR DESCRIPTION
I surfaced this testing Crush; chains with a Glamour issue.  LLM-assisted, but I read and understood the patch.

--- 
`Close` BEFORE reading `buf` so the trailing `ResetStyle / ResetHyperlink`
that the `WrapWriter` emits on close is included in the returned string.

Using `defer w.Close()` here would write the closing resets to buf *after* `buf.String()` snapshots it, dropping them from the return value and leaving callers with output that ends in a dangling SGR/OSC8 — which in turn trips a use-after-close panic in glamour's `IndentWriter.Close` write-cascade.

- [X ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
