### PR TITLE
fix: make GetBorder* getters consistent with applyBorder when no sides are explicit

### DIFF
--- a/get.go
+++ b/get.go
@@ -235,11 +235,16 @@ func (s Style) GetVerticalMargins() int {
 // border style, Border{} is returned. For all other unset values false is
 // returned.
 func (s Style) GetBorder() (b Border, top, right, bottom, left bool) {
-	return s.getBorderStyle(),
-		s.getAsBool(borderTopKey, false),
-		s.getAsBool(borderRightKey, false),
-		s.getAsBool(borderBottomKey, false),
-		s.getAsBool(borderLeftKey, false)
+	top = s.getAsBool(borderTopKey, false)
+	right = s.getAsBool(borderRightKey, false)
+	bottom = s.getAsBool(borderBottomKey, false)
+	left = s.getAsBool(borderLeftKey, false)
+	// When a border style is set but no sides are explicitly enabled,
+	// applyBorder renders all sides — mirror that behaviour here.
+	if s.isBorderStyleSetWithoutSides() {
+		top, right, bottom, left = true, true, true, true
+	}
+	return s.getBorderStyle(), top, right, bottom, left
 }
 
 // GetBorderStyle returns the style's border style (type Border). If no value
@@ -251,24 +256,36 @@ func (s Style) GetBorderStyle() Border {
 // GetBorderTop returns the style's top border setting. If no value is set
 // false is returned.
 func (s Style) GetBorderTop() bool {
+	if s.isBorderStyleSetWithoutSides() {
+		return true
+	}
 	return s.getAsBool(borderTopKey, false)
 }
 
 // GetBorderRight returns the style's right border setting. If no value is set
 // false is returned.
 func (s Style) GetBorderRight() bool {
+	if s.isBorderStyleSetWithoutSides() {
+		return true
+	}
 	return s.getAsBool(borderRightKey, false)
 }
 
 // GetBorderBottom returns the style's bottom border setting. If no value is
 // set false is returned.
 func (s Style) GetBorderBottom() bool {
+	if s.isBorderStyleSetWithoutSides() {
+		return true
+	}
 	return s.getAsBool(borderBottomKey, false)
 }
 
 // GetBorderLeft returns the style's left border setting. If no value is
 // set false is returned.
 func (s Style) GetBorderLeft() bool {
+	if s.isBorderStyleSetWithoutSides() {
+		return true
+	}
 	return s.getAsBool(borderLeftKey, false)
 }
 

--- a/style_test.go
+++ b/style_test.go
@@ -741,3 +741,29 @@ func BenchmarkStyleRender(b *testing.B) {
 		})
 	}
 }
+
+func TestGetBorderSidesWithBorderStyleOnly(t *testing.T) {
+	// Regression test for https://github.com/charmbracelet/lipgloss/issues/366:
+	// GetBorder* returned false when a border style was set via BorderStyle()
+	// without explicit BorderLeft/Top/Right/Bottom calls, even though applyBorder
+	// renders all sides in that case.
+	s := NewStyle().BorderStyle(NormalBorder())
+
+	if !s.GetBorderTop() {
+		t.Error("expected GetBorderTop() == true when border style is set without explicit sides")
+	}
+	if !s.GetBorderRight() {
+		t.Error("expected GetBorderRight() == true when border style is set without explicit sides")
+	}
+	if !s.GetBorderBottom() {
+		t.Error("expected GetBorderBottom() == true when border style is set without explicit sides")
+	}
+	if !s.GetBorderLeft() {
+		t.Error("expected GetBorderLeft() == true when border style is set without explicit sides")
+	}
+
+	_, top, right, bottom, left := s.GetBorder()
+	if !top || !right || !bottom || !left {
+		t.Errorf("expected GetBorder() sides all true, got top=%v right=%v bottom=%v left=%v", top, right, bottom, left)
+	}
+}

--- a/unset.go
+++ b/unset.go
@@ -184,26 +184,22 @@ func (s Style) UnsetBorderStyle() Style {
 
 // UnsetBorderTop removes the border top style rule, if set.
 func (s Style) UnsetBorderTop() Style {
-	s.unset(borderTopKey)
-	return s
+	return s.BorderTop(false)
 }
 
 // UnsetBorderRight removes the border right style rule, if set.
 func (s Style) UnsetBorderRight() Style {
-	s.unset(borderRightKey)
-	return s
+	return s.BorderRight(false)
 }
 
 // UnsetBorderBottom removes the border bottom style rule, if set.
 func (s Style) UnsetBorderBottom() Style {
-	s.unset(borderBottomKey)
-	return s
+	return s.BorderBottom(false)
 }
 
 // UnsetBorderLeft removes the border left style rule, if set.
 func (s Style) UnsetBorderLeft() Style {
-	s.unset(borderLeftKey)
-	return s
+	return s.BorderLeft(false)
 }
 
 // UnsetBorderForeground removes all border foreground color styles, if set.


### PR DESCRIPTION
## Summary

When `Border(style)` is called without explicit side arguments, `applyBorder` renders all four sides. However `GetBorderTop`, `GetBorderRight`, `GetBorderBottom`, and `GetBorderLeft` (and `GetBorder`) were not reflecting this — they always returned `false` in that case, making the getters inconsistent with the render behaviour.

## Changes

- `get.go`: `GetBorder`, `GetBorderTop/Right/Bottom/Left` now check `isBorderStyleSetWithoutSides()` and return `true` for all sides when a border style is set but no explicit side keys exist in props — exactly mirroring the condition `applyBorder` uses.
- `unset.go`: `UnsetBorderTop/Right/Bottom/Left` now call `BorderSide(false)` instead of removing the key from props. This keeps the key present (as `false`), which lets `isBorderStyleSetWithoutSides()` correctly distinguish "border style set, sides never configured" from "sides explicitly unset". This follows the same pattern as `UnsetUnderline` → `Underline(false)`.

## Testing

- Existing `TestStyleUnset` continues to pass.
- New test `TestGetBorderSidesWithBorderStyleOnly` verifies the fixed behaviour.

Fixes #366