### PR TITLE
fix(compat): honor NO_COLOR in init-time background query

### DIFF
--- a/compat/color.go
+++ b/compat/color.go
@@ -10,11 +10,35 @@ import (
 
 var (
 	// HasDarkBackground is true if the terminal has a dark background.
-	HasDarkBackground = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	//
+	// When the NO_COLOR environment variable is set (per
+	// https://no-color.org), this remains false and the background
+	// query is skipped to avoid the init-time stdin/stdout side
+	// effects (raw-mode toggle, OSC 11 + DA1 query writes, blocking
+	// stdin read) that would otherwise leak ANSI bytes into the
+	// terminal and steal pre-buffered stdin input under a PTY.
+	HasDarkBackground bool
 
 	// Profile is the color profile of the terminal.
-	Profile = colorprofile.Detect(os.Stdout, os.Environ())
+	Profile colorprofile.Profile
 )
+
+func init() {
+	// colorprofile.Detect reads only the environment and the stdout
+	// file descriptor; it has no stdin side effects, so it is always
+	// safe to run at init time. It honors NO_COLOR internally.
+	Profile = colorprofile.Detect(os.Stdout, os.Environ())
+
+	// Skip the background-color query when NO_COLOR is set. Per
+	// https://no-color.org, any non-empty value disables color
+	// behavior. HasDarkBackground therefore defaults to false, which
+	// callers interpret as a light background — the safer default
+	// when querying is disallowed.
+	if os.Getenv("NO_COLOR") != "" {
+		return
+	}
+	HasDarkBackground = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+}
 
 // AdaptiveColor provides color options for light and dark backgrounds. The
 // appropriate color will be returned at runtime based on the darkness of the


### PR DESCRIPTION
## Problem

`compat`'s package-level `var` block calls `lipgloss.HasDarkBackground(os.Stdin, os.Stdout)` at init time. That call:

1. Puts `os.Stdin` into raw mode via `term.MakeRaw`.
2. Writes OSC `]11;?\a` (background-color query) and CSI `[c` (DA1) to `os.Stdout`.
3. Blocks reading `os.Stdin` for the DA1 response with a 2-second timeout.

Because this runs during package initialization, **callers have no opportunity to opt out** — the side effects fire before any user code can check environment, set up redirection, or honor `NO_COLOR`. Two concrete downstream impacts:

- **`NO_COLOR` honor**: ANSI escape bytes leak into `stdout`, breaking CLI test harnesses that assert clean output and violating the [no-color.org](https://no-color.org/) spec ("when present, regardless of its value, prevents the addition of ANSI color").
- **PTY stdin theft**: under a PTY with pre-buffered input, lipgloss's ANSI parser consumes that input during the 2s query window, hanging downstream prompts in interactive CLIs.

## Fix

Move the background query out of the `var` block into an `init()` and gate it on `NO_COLOR`:

```go
func init() {
    Profile = colorprofile.Detect(os.Stdout, os.Environ())
    if os.Getenv("NO_COLOR") != "" {
        return
    }
    HasDarkBackground = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
}
```

Notes:

- `Profile` init stays unconditional — `colorprofile.Detect` is env+stdout only, no stdin side effects, and already honors `NO_COLOR` internally.
- `HasDarkBackground` defaults to `false` (zero value) when the query is skipped. Callers that branch on it (`AdaptiveColor.RGBA`, `CompleteAdaptiveColor.RGBA`) return the `Light` variant — the safer default when querying is disallowed.
- The public API is unchanged: `HasDarkBackground` and `Profile` remain exported package-level variables, not functions.
- Spec reference: https://no-color.org — any non-empty value disables color; this matches the `os.Getenv("NO_COLOR") != ""` check.

## Test coverage

No test was added: the `compat/` package has no existing test suite, and adding a framework from scratch felt out of scope for a focused fix. Manually verified that:

- `go build ./...` and `go vet ./...` are clean on the branch.
- With `NO_COLOR=1` set, importing `compat` no longer issues the OSC/DA1 bytes or touches stdin.
- Without `NO_COLOR`, behavior is unchanged from `main`.

Happy to add tests if maintainers prefer, just point me at the preferred fixture style.

## Scope

Single-file change limited to `compat/color.go`. No changes to the public API, no changes to other packages, no dependency bumps.