### PR TITLE
feat: allow multi-character corners on borders

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -403,11 +403,8 @@ func (s Style) applyBorder(str string) string {
 		}
 	}
 
-	// For now, limit corners to one rune.
-	border.TopLeft = getFirstRuneAsString(border.TopLeft)
-	border.TopRight = getFirstRuneAsString(border.TopRight)
-	border.BottomRight = getFirstRuneAsString(border.BottomRight)
-	border.BottomLeft = getFirstRuneAsString(border.BottomLeft)
+	// Corners may be multi-character strings. The renderHorizontalEdge
+	// function uses ansi.StringWidth to account for their display width.
 
 	var topFG, rightFG, bottomFG, leftFG color.Color
 	var (

--- a/borders_test.go
+++ b/borders_test.go
@@ -1,6 +1,7 @@
 package lipgloss
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/rivo/uniseg"
@@ -140,6 +141,84 @@ func TestGetFirstRuneAsString(t *testing.T) {
 				t.Errorf("getFirstRuneAsString(%q) = %q, but old implementation returns %q", tt.input, got, old)
 			}
 		})
+	}
+}
+
+func TestMultiCharacterCorners(t *testing.T) {
+	t.Parallel()
+
+	// Define a border with multi-character corners.
+	customBorder := Border{
+		Top:         "-",
+		Bottom:      "-",
+		Left:        "|",
+		Right:       "|",
+		TopLeft:     "##",
+		TopRight:    "##",
+		BottomLeft:  "##",
+		BottomRight: "##",
+	}
+
+	style := NewStyle().
+		Border(customBorder).
+		Width(10)
+
+	result := style.Render("Hi")
+	lines := strings.Split(result, "\n")
+
+	// The top border should start with "##" (multi-char corner).
+	if !strings.HasPrefix(lines[0], "##") {
+		t.Errorf("expected top border to start with '##', got: %q", lines[0])
+	}
+
+	// The top border should end with "##" (multi-char corner).
+	if !strings.HasSuffix(lines[0], "##") {
+		t.Errorf("expected top border to end with '##', got: %q", lines[0])
+	}
+
+	// The bottom border should also use multi-character corners.
+	lastLine := lines[len(lines)-1]
+	if !strings.HasPrefix(lastLine, "##") {
+		t.Errorf("expected bottom border to start with '##', got: %q", lastLine)
+	}
+	if !strings.HasSuffix(lastLine, "##") {
+		t.Errorf("expected bottom border to end with '##', got: %q", lastLine)
+	}
+
+	// Verify the top border contains the multi-character corner, not a single char.
+	// Before the fix, corners were truncated to 1 rune, so "##" would become "#".
+	if strings.HasPrefix(lines[0], "#-") {
+		t.Errorf("corner was truncated to single char (old behavior): %q", lines[0])
+	}
+}
+
+func TestMultiCharacterCornersAsymmetric(t *testing.T) {
+	t.Parallel()
+
+	// Different corner sizes.
+	customBorder := Border{
+		Top:         "=",
+		Bottom:      "=",
+		Left:        "|",
+		Right:       "|",
+		TopLeft:     ">>",
+		TopRight:    "<<",
+		BottomLeft:  ">>",
+		BottomRight: "<<",
+	}
+
+	style := NewStyle().
+		Border(customBorder).
+		Width(8)
+
+	result := style.Render("Test")
+	lines := strings.Split(result, "\n")
+
+	if !strings.HasPrefix(lines[0], ">>") {
+		t.Errorf("expected top border to start with '>>', got: %q", lines[0])
+	}
+	if !strings.HasSuffix(lines[0], "<<") {
+		t.Errorf("expected top border to end with '<<', got: %q", lines[0])
 	}
 }
 


### PR DESCRIPTION
## Description

Remove the single-rune truncation on border corners (`TopLeft`, `TopRight`, `BottomLeft`, `BottomRight`).

Currently, `applyBorder` truncates all corner strings to a single rune (lines 406-410 in `borders.go`):

```go
// For now, limit corners to one rune.
border.TopLeft = getFirstRuneAsString(border.TopLeft)
border.TopRight = getFirstRuneAsString(border.TopRight)
border.BottomRight = getFirstRuneAsString(border.BottomRight)
border.BottomLeft = getFirstRuneAsString(border.BottomLeft)
```

This prevents users from using multi-character corner decorations. However, the `renderHorizontalEdge` function already uses `ansi.StringWidth` to correctly handle multi-character left/right parts, so the truncation is unnecessary.

## What changed

- Removed the 4-line truncation block in `applyBorder`
- Replaced with a comment explaining corners may be multi-character
- Added tests verifying multi-character corners work correctly

## Example

With this change, you can create borders like:

```
┌──                 ── ┐
│                      │
│                      │
└──                 ── ┘
```

Using a custom border:

```go
customBorder := lipgloss.Border{
    Top:         "-",
    Bottom:      "-",
    Left:        "|",
    Right:       "|",
    TopLeft:     "──",
    TopRight:    "──",
    BottomLeft:  "──",
    BottomRight: "──",
}
```

Fixes #605