### PR TITLE
fix: disabling one border side no longer hides all sides

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -326,21 +326,13 @@ func (s Style) borderBlend(width, height int, colors ...color.Color) *borderBlen
 
 func (s Style) applyBorder(str string) string {
 	var (
-		border    = s.getBorderStyle()
-		hasTop    = s.getAsBool(borderTopKey, false)
-		hasRight  = s.getAsBool(borderRightKey, false)
-		hasBottom = s.getAsBool(borderBottomKey, false)
-		hasLeft   = s.getAsBool(borderLeftKey, false)
+		border      = s.getBorderStyle()
+		defaultSide = border != noBorder
+		hasTop      = s.getAsBool(borderTopKey, defaultSide)
+		hasRight    = s.getAsBool(borderRightKey, defaultSide)
+		hasBottom   = s.getAsBool(borderBottomKey, defaultSide)
+		hasLeft     = s.getAsBool(borderLeftKey, defaultSide)
 	)
-
-	// If a border is set and no sides have been specifically turned on or off
-	// render borders on all sides.
-	if s.isBorderStyleSetWithoutSides() {
-		hasTop = true
-		hasRight = true
-		hasBottom = true
-		hasLeft = true
-	}
 
 	// If no border is set or all borders are been disabled, abort.
 	if border == noBorder || (!hasTop && !hasRight && !hasBottom && !hasLeft) {

--- a/style_test.go
+++ b/style_test.go
@@ -644,6 +644,32 @@ func TestUnsetHyperlink(t *testing.T) {
 	}
 }
 
+// TestBorderStylePartialSides ensures that disabling individual border sides
+// via BorderStyle+BorderTop/Right/Bottom/Left(false) does not make all sides
+// disappear. Regression test for https://github.com/charmbracelet/lipgloss/issues/194.
+func TestBorderStylePartialSides(t *testing.T) {
+	b := NormalBorder()
+	content := "hi"
+
+	// All four sides should render with only a style set.
+	allSides := NewStyle().BorderStyle(b).Render(content)
+	if Height(allSides) != 3 || Width(allSides) != 4 {
+		t.Fatalf("expected 3 rows and 4 cols for all-sides border, got height=%d width=%d", Height(allSides), Width(allSides))
+	}
+
+	// Disabling only the top: right, bottom, left must still render.
+	noTop := NewStyle().BorderStyle(b).BorderTop(false).Render(content)
+	if Height(noTop) != 2 {
+		t.Fatalf("expected 2 rows (no top border), got %d\n%s", Height(noTop), noTop)
+	}
+
+	// Disabling only the left: top, right, bottom must still render.
+	noLeft := NewStyle().BorderStyle(b).BorderLeft(false).Render(content)
+	if Height(noLeft) != 3 {
+		t.Fatalf("expected 3 rows (no left border), got %d\n%s", Height(noLeft), noLeft)
+	}
+}
+
 func BenchmarkPad(b *testing.B) {
 	tests := []struct {
 		name string

--- a/unset.go
+++ b/unset.go
@@ -184,26 +184,22 @@ func (s Style) UnsetBorderStyle() Style {
 
 // UnsetBorderTop removes the border top style rule, if set.
 func (s Style) UnsetBorderTop() Style {
-	s.unset(borderTopKey)
-	return s
+	return s.BorderTop(false)
 }
 
 // UnsetBorderRight removes the border right style rule, if set.
 func (s Style) UnsetBorderRight() Style {
-	s.unset(borderRightKey)
-	return s
+	return s.BorderRight(false)
 }
 
 // UnsetBorderBottom removes the border bottom style rule, if set.
 func (s Style) UnsetBorderBottom() Style {
-	s.unset(borderBottomKey)
-	return s
+	return s.BorderBottom(false)
 }
 
 // UnsetBorderLeft removes the border left style rule, if set.
 func (s Style) UnsetBorderLeft() Style {
-	s.unset(borderLeftKey)
-	return s
+	return s.BorderLeft(false)
 }
 
 // UnsetBorderForeground removes all border foreground color styles, if set.


### PR DESCRIPTION
Fixes #194.

When a border style was set via `BorderStyle(b)` and then a single side was turned off (e.g. `BorderTop(false)`), the entire border disappeared instead of rendering the remaining three sides.

## Root cause

`applyBorder` defaulted every unset side key to `false`, then relied on `isBorderStyleSetWithoutSides()` to flip them to `true` when no side key was present. That helper returns `false` the moment any side key exists — even one explicitly set to `false` — so calling `BorderTop(false)` caused all remaining sides to vanish.

## Fix

- **`borders.go`**: use `defaultSide := border != noBorder` so each unset side inherits `true` whenever a border style is active. The now-redundant `isBorderStyleSetWithoutSides()` block in `applyBorder` is removed.
- **`unset.go`**: change `UnsetBorder{Top,Right,Bottom,Left}` to call `BorderSide(false)` (keeps the key in props as `false`) rather than removing the key, so "unset" consistently means "explicitly off" rather than "removed from props."

## Before / after

```go
// Before: entire border disappears
lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderTop(false).Render("hi")
// → "hi"  (no border at all)

// After: only the top side is missing
// → │hi│
//   └──┘
```