### PR TITLE
fix: prevent crash when writing to a closed wrap writer

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -63,6 +63,12 @@ func (w *WrapWriter) Link() uv.Link {
 
 // Write writes to the buffer.
 func (w *WrapWriter) Write(p []byte) (int, error) {
+	if w.p == nil {
+		// The writer has been closed and its parser returned to the pool.
+		// Writing after close can happen during out-of-order teardown of
+		// nested writer chains; treat it as a no-op rather than panicking.
+		return len(p), nil
+	}
 	for i := range p {
 		b := p[i]
 		w.p.Advance(b)

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -1,0 +1,28 @@
+package lipgloss
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestWrapWriterWriteAfterClose verifies that writing to a WrapWriter after it
+// has been closed is a safe no-op rather than a nil-pointer panic. Close()
+// returns the internal ANSI parser to a sync.Pool and nils it out; out-of-order
+// teardown of nested writer chains can route a trailing style/link reset back
+// through an already-closed writer, so Write must tolerate a nil parser.
+func TestWrapWriterWriteAfterClose(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWrapWriter(&buf)
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	n, err := w.Write([]byte("after close"))
+	if err != nil {
+		t.Fatalf("write after close: %v", err)
+	}
+	if n != len("after close") {
+		t.Fatalf("write after close: got n=%d, want %d", n, len("after close"))
+	}
+}


### PR DESCRIPTION
## Summary

A `WrapWriter` panics with a nil pointer dereference if it is written to after being closed. `Close()` returns the internal ANSI parser to a `sync.Pool` and nils the reference, but `Write` dereferenced it unconditionally.

This surfaces when nested writer chains tear down out of order: closing an outer writer can flush a trailing style or link reset back through a writer that was already closed, crashing the program. Glamour's block rendering hits this when a styled run is left open across an indent or margin boundary (common when rendering partial/streamed markdown).

## Fix

Treat a write after close as a safe no-op rather than a fatal panic. A closed writer has nothing useful to do with further bytes, so swallowing them keeps out-of-order teardown safe.

## Test

`TestWrapWriterWriteAfterClose` writes after close and asserts no panic. It fails (nil pointer dereference) without the guard and passes with it.


💘 Generated with Crush