### PR TITLE
fix: use actual border size in GetBorderXxxSize when BorderStyle is set without sides

### DIFF
--- a/get.go
+++ b/get.go
@@ -345,10 +345,7 @@ func (s Style) GetBorderTopWidth() int {
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the top edge, 0 is returned.
 func (s Style) GetBorderTopSize() int {
-	if s.isBorderStyleSetWithoutSides() {
-		return 1
-	}
-	if !s.getAsBool(borderTopKey, false) {
+	if !s.isBorderStyleSetWithoutSides() && !s.getAsBool(borderTopKey, false) {
 		return 0
 	}
 	return s.getBorderStyle().GetTopSize()
@@ -358,10 +355,7 @@ func (s Style) GetBorderTopSize() int {
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the left edge, 0 is returned.
 func (s Style) GetBorderLeftSize() int {
-	if s.isBorderStyleSetWithoutSides() {
-		return 1
-	}
-	if !s.getAsBool(borderLeftKey, false) {
+	if !s.isBorderStyleSetWithoutSides() && !s.getAsBool(borderLeftKey, false) {
 		return 0
 	}
 	return s.getBorderStyle().GetLeftSize()
@@ -369,12 +363,9 @@ func (s Style) GetBorderLeftSize() int {
 
 // GetBorderBottomSize returns the width of the bottom border. If borders
 // contain runes of varying widths, the widest rune is returned. If no border
-// exists on the left edge, 0 is returned.
+// exists on the bottom edge, 0 is returned.
 func (s Style) GetBorderBottomSize() int {
-	if s.isBorderStyleSetWithoutSides() {
-		return 1
-	}
-	if !s.getAsBool(borderBottomKey, false) {
+	if !s.isBorderStyleSetWithoutSides() && !s.getAsBool(borderBottomKey, false) {
 		return 0
 	}
 	return s.getBorderStyle().GetBottomSize()
@@ -384,10 +375,7 @@ func (s Style) GetBorderBottomSize() int {
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the right edge, 0 is returned.
 func (s Style) GetBorderRightSize() int {
-	if s.isBorderStyleSetWithoutSides() {
-		return 1
-	}
-	if !s.getAsBool(borderRightKey, false) {
+	if !s.isBorderStyleSetWithoutSides() && !s.getAsBool(borderRightKey, false) {
 		return 0
 	}
 	return s.getBorderStyle().GetRightSize()

--- a/get.go
+++ b/get.go
@@ -344,6 +344,10 @@ func (s Style) GetBorderTopWidth() int {
 // GetBorderTopSize returns the width of the top border. If borders contain
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the top edge, 0 is returned.
+//
+// Width measurement uses the same maxRuneWidth helper as applyBorder, so this
+// getter and the renderer are always consistent — including on systems where
+// Unicode East-Asian-Width ambiguous runes are reported as wide.
 func (s Style) GetBorderTopSize() int {
 	if !s.isBorderStyleSetWithoutSides() && !s.getAsBool(borderTopKey, false) {
 		return 0
@@ -354,6 +358,10 @@ func (s Style) GetBorderTopSize() int {
 // GetBorderLeftSize returns the width of the left border. If borders contain
 // runes of varying widths, the widest rune is returned. If no border exists on
 // the left edge, 0 is returned.
+//
+// Width measurement uses the same maxRuneWidth helper as applyBorder, so this
+// getter and the renderer are always consistent — including on systems where
+// Unicode East-Asian-Width ambiguous runes are reported as wide.
 func (s Style) GetBorderLeftSize() int {
 	if !s.isBorderStyleSetWithoutSides() && !s.getAsBool(borderLeftKey, false) {
 		return 0
@@ -364,6 +372,10 @@ func (s Style) GetBorderLeftSize() int {
 // GetBorderBottomSize returns the width of the bottom border. If borders
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the bottom edge, 0 is returned.
+//
+// Width measurement uses the same maxRuneWidth helper as applyBorder, so this
+// getter and the renderer are always consistent — including on systems where
+// Unicode East-Asian-Width ambiguous runes are reported as wide.
 func (s Style) GetBorderBottomSize() int {
 	if !s.isBorderStyleSetWithoutSides() && !s.getAsBool(borderBottomKey, false) {
 		return 0
@@ -374,6 +386,10 @@ func (s Style) GetBorderBottomSize() int {
 // GetBorderRightSize returns the width of the right border. If borders
 // contain runes of varying widths, the widest rune is returned. If no border
 // exists on the right edge, 0 is returned.
+//
+// Width measurement uses the same maxRuneWidth helper as applyBorder, so this
+// getter and the renderer are always consistent — including on systems where
+// Unicode East-Asian-Width ambiguous runes are reported as wide.
 func (s Style) GetBorderRightSize() int {
 	if !s.isBorderStyleSetWithoutSides() && !s.getAsBool(borderRightKey, false) {
 		return 0

--- a/style_test.go
+++ b/style_test.go
@@ -741,3 +741,49 @@ func BenchmarkStyleRender(b *testing.B) {
 		})
 	}
 }
+
+func TestBorderSizeGettersWithBorderStyleOnly(t *testing.T) {
+	t.Parallel()
+
+	// When BorderStyle() is used without explicitly enabling individual sides,
+	// the renderer defaults all four sides to visible. The size getters must
+	// agree with what the renderer actually draws rather than returning a
+	// hardcoded 1 regardless of the border's actual character widths.
+
+	t.Run("normal border horizontal size", func(t *testing.T) {
+		s := NewStyle().BorderStyle(NormalBorder())
+		requireEqual(t, 2, s.GetHorizontalBorderSize())
+	})
+
+	t.Run("normal border vertical size", func(t *testing.T) {
+		s := NewStyle().BorderStyle(NormalBorder())
+		requireEqual(t, 2, s.GetVerticalBorderSize())
+	})
+
+	t.Run("horizontal frame size includes border and padding", func(t *testing.T) {
+		// left border(1) + right border(1) + left pad(2) + right pad(2) = 6
+		s := NewStyle().BorderStyle(NormalBorder()).Padding(1, 2)
+		requireEqual(t, 6, s.GetHorizontalFrameSize())
+	})
+
+	t.Run("vertical frame size includes border and padding", func(t *testing.T) {
+		// top border(1) + bottom border(1) + top pad(1) + bottom pad(1) = 4
+		s := NewStyle().BorderStyle(NormalBorder()).Padding(1, 2)
+		requireEqual(t, 4, s.GetVerticalFrameSize())
+	})
+
+	t.Run("wide custom border left size", func(t *testing.T) {
+		// A custom border whose vertical sides use fullwidth characters (display
+		// width 2). GetBorderLeftSize / GetBorderRightSize must return 2.
+		b := NormalBorder()
+		b.Left = "｜" // U+FF5C FULLWIDTH VERTICAL LINE, display width 2
+		b.Right = "｜"
+		b.TopLeft = "｜"
+		b.TopRight = "｜"
+		b.BottomLeft = "｜"
+		b.BottomRight = "｜"
+		s := NewStyle().BorderStyle(b)
+		requireEqual(t, 2, s.GetBorderLeftSize())
+		requireEqual(t, 2, s.GetBorderRightSize())
+	})
+}


### PR DESCRIPTION
When `BorderStyle()` is used without explicitly enabling individual sides,
`isBorderStyleSetWithoutSides()` returns true and the renderer correctly
enables all four sides. The `GetBorderTopSize`, `GetBorderLeftSize`,
`GetBorderBottomSize`, and `GetBorderRightSize` getters were returning a
hardcoded `1` in that path, ignoring the actual width of the border's
characters.

This causes `GetHorizontalFrameSize` / `GetVerticalFrameSize` to return
wrong values whenever the border's side characters have a display width
other than 1 (e.g. a custom border using fullwidth Unicode glyphs), and
makes `BorderStyle()` + `Padding()` layout math inconsistent with what
the renderer actually draws.

The fix replaces the hardcoded early-return with a call to the border
struct's own `GetXxxSize()` getter, which already measures actual rune
widths via `maxRuneWidth`. The two branches now share the same tail call,
so the condition simplifies to a single combined check.

Also corrects a stale comment in `GetBorderBottomSize` that referred to
the "left edge" instead of the "bottom edge".

Regression test added in `style_test.go` covering `NormalBorder()` via
`BorderStyle()` alone, `BorderStyle()` + `Padding()`, and a custom border
with fullwidth vertical-line characters that triggered the wrong result
before this fix.