### PR TITLE
fix: pad horizontal border edge with wide middle runes

### DIFF
--- a/borders.go
+++ b/borders.go
@@ -509,10 +509,21 @@ func renderHorizontalEdge(left, middle, right string, width int) string {
 	out := strings.Builder{}
 	out.WriteString(left)
 
-	for i := 0; i < width-leftWidth-rightWidth; {
+	inner := width - leftWidth - rightWidth
+	for i := 0; i < inner; {
 		r := runes[j]
+		rw := ansi.StringWidth(string(r))
+		if i+rw > inner {
+			// The next rune is too wide to fit in the remaining space (e.g. a
+			// wide middle rune against an odd inner width). Pad with a single
+			// space so we land exactly on the target width instead of
+			// overshooting it.
+			out.WriteRune(' ')
+			i++
+			continue
+		}
 		out.WriteRune(r)
-		i += ansi.StringWidth(string(r))
+		i += rw
 		j++
 		if j >= len(runes) {
 			j = 0

--- a/borders_test.go
+++ b/borders_test.go
@@ -3,6 +3,7 @@ package lipgloss
 import (
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/rivo/uniseg"
 )
 
@@ -221,4 +222,27 @@ func maxRuneWidthOld(str string) int {
 	}
 
 	return width
+}
+
+func TestRenderHorizontalEdgeWideMiddle(t *testing.T) {
+	tests := []struct {
+		name      string
+		left, mid string
+		right     string
+		width     int
+	}{
+		{"WideMid_EvenInner", "X", "あ", "Y", 6}, // inner 4: あ あ -> 4 cells
+		{"WideMid_OddInner", "X", "あ", "Y", 7},  // inner 5: must not overshoot to 6
+		{"WideMid_NoCorners", "", "あ", "", 5},   // inner 5
+		{"NarrowMid_Odd", "X", "-", "Y", 7},     // inner 5, baseline
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderHorizontalEdge(tt.left, tt.mid, tt.right, tt.width)
+			if w := ansi.StringWidth(got); w != tt.width {
+				t.Errorf("renderHorizontalEdge(%q,%q,%q,%d) width = %d, want %d (out=%q)",
+					tt.left, tt.mid, tt.right, tt.width, w, tt.width, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

A custom border whose `Top`/`Bottom` is a **wide (2-cell) rune** (e.g. CJK or box-art) renders the box one cell too wide when the inner span is odd. The top/bottom edges then don't line up with the body:

```
before:            after:
┌ああ┐  (w=6)       ┌あ ┐  (w=5)
│abc│  (w=5)        │abc│  (w=5)
└ああ┘  (w=6)       └あ ┘  (w=5)
```

## Cause

In `renderHorizontalEdge` (`borders.go`) the fill loop checks `i < inner` **before** writing, then advances `i` by the rune's full cell width. When the middle rune is 2 cells wide and only one cell of space remains, it still writes the whole rune, overshooting the target width by one.

## Fix

If the next rune is too wide for the remaining space, write a single space instead so the edge lands exactly on the requested width. Narrow (1-cell) runes and even inner widths are unaffected — the built-in borders all use 1-cell runes, so default rendering doesn't change.

## Test

`TestRenderHorizontalEdgeWideMiddle` asserts `ansi.StringWidth(out) == width` across wide/narrow runes and odd/even inner spans. It fails before the change (`width = 8, want 7`) and passes after. `go test ./...` is green.