### PR TITLE
fix(tree): remove incorrect start/end swap in Offset

### DIFF
--- a/tree/tree.go
+++ b/tree/tree.go
@@ -118,19 +118,17 @@ func (t *Tree) Hide(hide bool) *Tree {
 // SetHidden hides a Tree node.
 func (t *Tree) SetHidden(hidden bool) { t.Hide(hidden) }
 
-// Offset sets the Tree children offsets.
+// Offset sets the Tree children offsets. Start is the number of children to
+// skip from the beginning, and end is the number of children to skip from the
+// end. For example, Offset(2, 1) on [A, B, C, D, E] yields [C, D].
+//
+// Passing a negative value for either parameter treats it as zero (no offset).
 func (t *Tree) Offset(start, end int) *Tree {
-	if start > end {
-		_start := start
-		start = end
-		end = _start
-	}
-
 	if start < 0 {
 		start = 0
 	}
-	if end < 0 || end > t.children.Length() {
-		end = t.children.Length()
+	if end < 0 {
+		end = 0
 	}
 
 	t.offset[0] = start
@@ -363,8 +361,26 @@ func (t *Tree) Width(width int) *Tree {
 
 // Children returns the children of a node.
 func (t *Tree) Children() Children {
+	start := t.offset[0]
+	end := t.offset[1]
+	n := t.children.Length()
+
+	// Clamp offsets to valid range.
+	if start < 0 {
+		start = 0
+	}
+	if start > n {
+		start = n
+	}
+	if end < 0 {
+		end = 0
+	}
+	if end > n-start {
+		end = n - start
+	}
+
 	var data []Node
-	for i := t.offset[0]; i < t.children.Length()-t.offset[1]; i++ {
+	for i := start; i < n-end; i++ {
 		data = append(data, t.children.At(i))
 	}
 	return NodeChildren(data)

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -319,6 +319,111 @@ func TestAt(t *testing.T) {
 	}
 }
 
+func TestTreeOffset(t *testing.T) {
+	build := func() *tree.Tree {
+		return tree.New().
+			Root("Root").
+			Child("A", "B", "C", "D", "E")
+	}
+
+	t.Run("zero_offset", func(t *testing.T) {
+		// Offset(0,0) should show all children.
+		tr := build()
+		tr.Offset(0, 0)
+		got := tr.Children()
+		want := []string{"A", "B", "C", "D", "E"}
+		assertChildren(t, got, want)
+	})
+
+	t.Run("skip_from_start", func(t *testing.T) {
+		// Offset(2,0) should skip A,B → show C,D,E.
+		tr := build()
+		tr.Offset(2, 0)
+		got := tr.Children()
+		want := []string{"C", "D", "E"}
+		assertChildren(t, got, want)
+	})
+
+	t.Run("skip_from_end", func(t *testing.T) {
+		// Offset(0,2) should skip D,E → show A,B,C.
+		tr := build()
+		tr.Offset(0, 2)
+		got := tr.Children()
+		want := []string{"A", "B", "C"}
+		assertChildren(t, got, want)
+	})
+
+	t.Run("skip_from_both", func(t *testing.T) {
+		// Offset(2,1) should skip A,B from start and E from end → show C,D.
+		tr := build()
+		tr.Offset(2, 1)
+		got := tr.Children()
+		want := []string{"C", "D"}
+		assertChildren(t, got, want)
+	})
+
+	t.Run("start_greater_than_end", func(t *testing.T) {
+		// Offset(3,1) — start > end is valid, no swap should happen.
+		// Skip A,B,C from start, skip E from end → show D.
+		tr := build()
+		tr.Offset(3, 1)
+		got := tr.Children()
+		want := []string{"D"}
+		assertChildren(t, got, want)
+	})
+
+	t.Run("offset_larger_than_children", func(t *testing.T) {
+		// Offset(10,0) should produce empty children.
+		tr := build()
+		tr.Offset(10, 0)
+		got := tr.Children()
+		if got.Length() != 0 {
+			t.Errorf("expected 0 children, got %d", got.Length())
+		}
+	})
+
+	t.Run("negative_values_clamped_to_zero", func(t *testing.T) {
+		// Negative values should be treated as zero.
+		tr := build()
+		tr.Offset(-1, -2)
+		got := tr.Children()
+		want := []string{"A", "B", "C", "D", "E"}
+		assertChildren(t, got, want)
+	})
+
+	t.Run("offset_swallows_all", func(t *testing.T) {
+		// Offset(2,3) on 5 items: skip A,B + C,D,E = nothing left.
+		tr := build()
+		tr.Offset(2, 3)
+		got := tr.Children()
+		if got.Length() != 0 {
+			t.Errorf("expected 0 children, got %d", got.Length())
+		}
+	})
+
+	t.Run("equal_offset", func(t *testing.T) {
+		// Offset(1,1) on 5 items: skip A + skip E → show B,C,D.
+		tr := build()
+		tr.Offset(1, 1)
+		got := tr.Children()
+		want := []string{"B", "C", "D"}
+		assertChildren(t, got, want)
+	})
+}
+
+func assertChildren(t *testing.T, got tree.Children, want []string) {
+	t.Helper()
+	if got.Length() != len(want) {
+		t.Errorf("expected %d children, got %d", len(want), got.Length())
+		return
+	}
+	for i, w := range want {
+		if got.At(i).Value() != w {
+			t.Errorf("expected child %d to be %q, got %q", i, w, got.At(i).Value())
+		}
+	}
+}
+
 func TestFilter(t *testing.T) {
 	data := tree.NewFilter(tree.NewStringData(
 		"Foo",


### PR DESCRIPTION
## Problem

`Tree.Offset(start, end)` incorrectly swaps `start` and `end` when `start > end`. This makes `Offset(2, 1)` behave like `Offset(1, 2)`, hiding rows from the wrong end of the tree.

Reported in #535 — calling `Offset(2, 1)` on `[Duck, Duck, Goose, Duck, Duck]` should skip 2 from the start and 1 from the end, but the swap inverts the meaning so you end up skipping 1 from the start and 2 from the end instead.

## Fix

- **Removed the start/end swap** in `Offset()`. The parameters now mean what they say: `start` = rows to skip from the beginning, `end` = rows to skip from the end. No magic reordering.
- **Added bounds clamping in `Children()`** so out-of-range offsets produce empty results instead of panicking on negative loop bounds.
- **Negative values are clamped to zero** in `Offset()`.
- **Improved doc comment** on `Offset()` to explain what the parameters actually do.

## Comparison with #612

This PR builds on the same core insight as #612 (remove the swap), but goes further:

1. **Bounds safety**: The existing `Children()` method could produce negative loop bounds if `offset[1] > children.Length()`. This PR adds explicit clamping so the iteration is always safe.
2. **Better negative handling**: Old code treated negative `end` as "use children length" — this treated `Offset(0, -1)` as "show everything". The new behavior treats all negative values as zero, which is more intuitive.
3. **Comprehensive tests**: 9 test cases covering zero offset, skip from start, skip from end, skip from both, `start > end` (the core bug), offset larger than children, negative values, offset that swallows all items, and equal offsets.

## Test Results

```
=== RUN   TestTreeOffset
--- PASS: TestTreeOffset (0.00s)
    --- PASS: zero_offset
    --- PASS: skip_from_start
    --- PASS: skip_from_end
    --- PASS: skip_from_both
    --- PASS: start_greater_than_end
    --- PASS: offset_larger_than_children
    --- PASS: negative_values_clamped_to_zero
    --- PASS: offset_swallows_all
    --- PASS: equal_offset
```

Full suite passes: `ok  charm.land/lipgloss/v2/tree  0.216s`

Closes #535