### PR TITLE
feat(table): add OverflowRow option to disable overflow row

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -71,6 +71,7 @@ type Table struct {
 	firstVisibleRowIndex int
 	lastVisibleRowIndex  int
 	overflowHeight       int
+	overflowRow          bool
 }
 
 // New returns a new Table that can be modified through different
@@ -88,6 +89,7 @@ func New() *Table {
 		borderRight:  true,
 		borderTop:    true,
 		wrap:         true,
+		overflowRow:  true,
 		data:         NewStringData(),
 	}
 }
@@ -251,6 +253,22 @@ func (t *Table) GetBorderRow() bool {
 	return t.borderRow
 }
 
+// OverflowRow sets whether to show an overflow row when the table content
+// exceeds the configured height. The overflow row displays an ellipsis (…)
+// in each column to indicate that there are more rows below.
+//
+// Set to false to disable the overflow row, useful when implementing
+// custom pagination or when the overflow indicator is not desired.
+func (t *Table) OverflowRow(v bool) *Table {
+	t.overflowRow = v
+	return t
+}
+
+// GetOverflowRow returns whether the overflow row is enabled.
+func (t *Table) GetOverflowRow() bool {
+	return t.overflowRow
+}
+
 // Width sets the table width, this auto-sizes the columns to fit the width by
 // either expanding or contracting the widths of each column as a best effort
 // approach.
@@ -354,7 +372,7 @@ func (t *Table) String() string {
 		}
 
 		// Add an overflow row to show that there are more rows not being rendered.
-		if t.lastVisibleRowIndex != -2 {
+		if t.lastVisibleRowIndex != -2 && t.overflowRow {
 			sb.WriteString(t.constructRow(t.lastVisibleRowIndex+1, true))
 		}
 	}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1595,3 +1595,70 @@ func TestWrapStyleFuncContent(t *testing.T) {
 		Wrap(true)
 	golden.RequireEqual(t, []byte(table.String()))
 }
+
+func TestOverflowRowDisabled(t *testing.T) {
+	headers := []string{"Rank", "City", "Country"}
+	rows := [][]string{
+		{"1", "Tokyo", "Japan"},
+		{"2", "Delhi", "India"},
+		{"3", "Shanghai", "China"},
+		{"4", "Dhaka", "Bangladesh"},
+		{"5", "São Paulo", "Brazil"},
+	}
+
+	t.Run("overflow_enabled_default", func(t *testing.T) {
+		// Default behavior: overflow row should appear.
+		table := New().
+			Headers(headers...).
+			Rows(rows...).
+			Height(5)
+
+		output := table.String()
+		if !strings.Contains(output, "…") {
+			t.Error("expected overflow row with ellipsis when overflow is enabled")
+		}
+	})
+
+	t.Run("overflow_disabled", func(t *testing.T) {
+		// With OverflowRow(false), no overflow row should appear.
+		table := New().
+			Headers(headers...).
+			Rows(rows...).
+			Height(5).
+			OverflowRow(false)
+
+		output := table.String()
+		if strings.Contains(output, "…") {
+			t.Errorf("expected no overflow row when OverflowRow is disabled, got:\n%s", output)
+		}
+	})
+
+	t.Run("overflow_disabled_shows_all", func(t *testing.T) {
+		// When height is large enough, disabling overflow should make no difference.
+		tableEnabled := New().
+			Headers(headers...).
+			Rows(rows...).
+			Height(100)
+
+		tableDisabled := New().
+			Headers(headers...).
+			Rows(rows...).
+			Height(100).
+			OverflowRow(false)
+
+		if tableEnabled.String() != tableDisabled.String() {
+			t.Error("expected same output when all rows fit regardless of overflow setting")
+		}
+	})
+
+	t.Run("getter", func(t *testing.T) {
+		table := New()
+		if !table.GetOverflowRow() {
+			t.Error("expected OverflowRow to be true by default")
+		}
+		table.OverflowRow(false)
+		if table.GetOverflowRow() {
+			t.Error("expected OverflowRow to be false after setting")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

When a table has more data rows than can fit in its configured `Height`, lipgloss renders an overflow row with `…` in each column. This tells the user there are more rows below. But if you're implementing pagination, that overflow row is redundant — you already know there are more pages.

Reported in #557.

## Fix

Added `OverflowRow(bool)` and `GetOverflowRow()` to `Table`. Default is `true` (preserve existing behavior). Set to `false` to suppress the overflow row entirely.

```go
table := table.New().
    Headers("Name", "Country").
    Row("Alice", "US").
    Row("Bob", "UK").
    Row("Carol", "DE").
    Row("Dave", "FR").
    Row("Eve", "JP").
    Height(5).
    OverflowRow(false)   // <-- no more "…" row
```

The change is minimal: a `bool` field on `Table`, a setter, a getter, and one condition in `String()` that gates the overflow row rendering. No changes to the height/scroll calculation logic.

## Tests

4 new sub-tests under `TestOverflowRowDisabled`:
- `overflow_enabled_default`: confirms `…` appears with default settings
- `overflow_disabled`: confirms `…` is gone when `OverflowRow(false)`
- `overflow_disabled_shows_all`: confirms output is identical when all rows fit regardless of setting
- `getter`: confirms `GetOverflowRow()` returns correct defaults and after mutation

Full test suite: `ok  charm.land/lipgloss/v2/table  0.279s`

Closes #557