### PR TITLE
docs: fix GetTabWidth comment on the unset return value

### DIFF
--- a/get.go
+++ b/get.go
@@ -425,8 +425,9 @@ func (s Style) GetMaxHeight() int {
 	return s.getAsInt(maxHeightKey)
 }
 
-// GetTabWidth returns the style's tab width setting. If no value is set 4 is
-// returned which is the implicit default.
+// GetTabWidth returns the style's tab width setting, i.e. the value passed to
+// [Style.TabWidth]. If no tab width has been set 0 is returned; tabs are still
+// expanded to 4 spaces at render time when no width is set.
 func (s Style) GetTabWidth() int {
 	return s.getAsInt(tabWidthKey)
 }


### PR DESCRIPTION
The doc comment on `GetTabWidth` says an unset tab width returns 4:

> If no value is set 4 is returned which is the implicit default.

It returns 0, not 4. The getter is `return s.getAsInt(tabWidthKey)`, and `getAsInt` returns 0 for an unset key, so `NewStyle().GetTabWidth()` is 0. The default of 4 is applied later, in `maybeConvertTabs` at render time, not by the getter. `TestStyleUnset` already asserts `GetTabWidth() != 4` after `UnsetTabWidth`, so the current return value is intended and the comment is the part that's wrong.

This corrects the comment to match the behavior: the getter returns the configured value (0 when unset), and tabs still expand to 4 spaces at render time when no width is set.

`gofmt`, `go vet`, `go build`, and `go test ./...` are clean.
