### PR TITLE
fix: preserve word separation in inline multiline render

### DIFF
--- a/style.go
+++ b/style.go
@@ -399,9 +399,9 @@ func (s Style) Render(strs ...string) string {
 	// carriage returns can cause strange behaviour when rendering.
 	str = strings.ReplaceAll(str, "\r\n", "\n")
 
-	// Strip newlines in single line mode
+	// Collapse newlines to spaces in single line mode so words stay separated.
 	if inline {
-		str = strings.ReplaceAll(str, "\n", "")
+		str = strings.TrimRight(strings.ReplaceAll(str, "\n", " "), " ")
 	}
 
 	// Include borders in block size.

--- a/style_test.go
+++ b/style_test.go
@@ -97,6 +97,24 @@ func TestStrikethrough(t *testing.T) {
 	}
 }
 
+func TestInlineNewlineSpacing(t *testing.T) {
+	t.Parallel()
+
+	style := NewStyle().Inline(true)
+
+	got := style.Render("hello\nworld")
+	want := "hello world"
+	if got != want {
+		t.Fatalf("Render(%q) = %q, want %q", "hello\nworld", got, want)
+	}
+
+	got = style.Render("hello\nworld\n")
+	want = "hello world"
+	if got != want {
+		t.Fatalf("Render(%q) = %q, want %q", "hello\nworld\n", got, want)
+	}
+}
+
 func TestStyleRender(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

When `Style.Inline(true)` renders multiline text, newlines are now replaced with spaces instead of being stripped. This keeps words on separate lines separated in the single-line output (e.g. `hello\nworld` → `hello world`).

## Motivation

Fixes #116. The previous behavior concatenated words across line breaks (`helloworld`), which breaks inline styling of multiline user input and conflicts with the CSS-like inline/span mental model described in the issue.

## Changes

- In `style.go`, inline mode now collapses `\n` to a space and trims trailing whitespace from removed final newlines.
- Added `TestInlineNewlineSpacing` covering the core case and a trailing-newline input.

## Tests

```bash
go test ./... -count=1
```

All packages pass locally (`charm.land/lipgloss/v2`, `list`, `table`, `tree`).

## Notes

- `\r\n` inputs are already normalized to `\n` earlier in the render path.
- Multiple consecutive newlines produce multiple spaces (`hello\n\nworld` → `hello  world`), which matches treating each line break as a word boundary.
- This is a behavior change for inline mode only; block rendering is unchanged.