### PR TITLE
fix: terminate margin background on each line

### DIFF
--- a/style.go
+++ b/style.go
@@ -568,11 +568,15 @@ func (s Style) applyMargins(str string, inline bool) string {
 		_, width := getLines(str)
 		spaces := strings.Repeat(" ", width)
 
+		// Style each margin line on its own so the reset lands before the
+		// newline, not at the start of the next line (see #115).
 		if topMargin > 0 {
-			str = style.Styled(strings.Repeat(spaces+"\n", topMargin)) + str
+			line := style.Styled(spaces)
+			str = strings.Repeat(line+"\n", topMargin) + str
 		}
 		if bottomMargin > 0 {
-			str += style.Styled(strings.Repeat("\n"+spaces, bottomMargin))
+			line := style.Styled(spaces)
+			str += strings.Repeat("\n"+line, bottomMargin)
 		}
 	}
 

--- a/style_test.go
+++ b/style_test.go
@@ -51,6 +51,19 @@ func TestUnderline(t *testing.T) {
 	}
 }
 
+func TestMarginBackground(t *testing.T) {
+	t.Parallel()
+
+	// The background reset must terminate each margin line before its newline,
+	// not leak onto the start of the next line, and the bottom margin line must
+	// be colored too (#115).
+	s := NewStyle().MarginBackground(Color("9")).Margin(1, 0)
+	expected := "\x1b[101m  \x1b[m\nhi\n\x1b[101m  \x1b[m"
+	if res := s.Render("hi"); res != expected {
+		t.Errorf("expected:\n%q\n\nactual:\n%q", expected, res)
+	}
+}
+
 func TestGetUnderlineColor(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
With `MarginBackground`, the SGR reset landed on the wrong side of the newline: on the top margin the `[0m` reset appeared at the start of the following line instead of the end of the margin line, and the bottom margin line was left uncolored (#115).

`applyMargins` styled the whole `spaces\n…` block in one call, so `Styled` placed the reset after the trailing newline. This styles each margin line on its own so the reset terminates the line before its newline.

`NewStyle().MarginBackground(Color("9")).Margin(1, 0).Render("hi")`:

```
- "\x1b[101m  \n\x1b[mhi\x1b[101m\n  \x1b[m"
+ "\x1b[101m  \x1b[m\nhi\n\x1b[101m  \x1b[m"
```

Added a regression test; the full suite passes.

Fixes #115