### PR TITLE
fix(query): don't query the terminal on handles that are not terminals

### DIFF
--- a/query.go
+++ b/query.go
@@ -3,7 +3,6 @@ package lipgloss
 import (
 	"fmt"
 	"image/color"
-	"os"
 	"runtime"
 
 	"github.com/charmbracelet/x/term"
@@ -32,31 +31,24 @@ func backgroundColor(in term.File, out term.File) (color.Color, error) {
 // This function is intended for standalone Lip Gloss use only. If you're using
 // Bubble Tea, listen for tea.BackgroundColorMsg in your update function.
 func BackgroundColor(in term.File, out term.File) (bg color.Color, err error) {
-	if runtime.GOOS == "windows" { //nolint:nestif
-		// On Windows, when the input/output is redirected or piped, we need to
-		// open the console explicitly.
-		// See https://learn.microsoft.com/en-us/windows/console/getstdhandle#remarks
-		if !term.IsTerminal(in.Fd()) {
-			f, err := os.OpenFile("CONIN$", os.O_RDWR, 0o644) //nolint:gosec
-			if err != nil {
-				return nil, fmt.Errorf("error opening CONIN$: %w", err)
-			}
-			in = f
-		}
-		if !term.IsTerminal(out.Fd()) {
-			f, err := os.OpenFile("CONOUT$", os.O_RDWR, 0o644) //nolint:gosec
-			if err != nil {
-				return nil, fmt.Errorf("error opening CONOUT$: %w", err)
-			}
-			out = f
-		}
-		return backgroundColor(in, out)
-	}
-
-	// NOTE: On Unix, one of the given files must be a tty.
+	// Detecting the background color means writing an escape sequence and blocking
+	// until the terminal answers it. Only a terminal ever answers, so both handles
+	// have to be terminals.
+	//
+	// Windows used to be special-cased here: when a handle was not a terminal it
+	// opened CONIN$/CONOUT$ and queried the console anyway. That made a program
+	// whose stdio is redirected -- a service, a CI job -- query a console nobody is
+	// watching, and wait for a reply that never comes.
 	if !term.IsTerminal(in.Fd()) || !term.IsTerminal(out.Fd()) {
 		return nil, fmt.Errorf("input/output is not a terminal")
 	}
+
+	if runtime.GOOS == "windows" {
+		// Console input and output are separate handles on Windows, so query the
+		// pair rather than treating either one as bidirectional.
+		return backgroundColor(in, out)
+	}
+
 	for _, f := range []term.File{in, out} {
 		if bg, err = backgroundColor(f, f); err == nil {
 			return bg, nil

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,66 @@
+package lipgloss
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// Pipes are not terminals, so there is nothing to answer a background color
+// query. BackgroundColor must say so and return, not wait.
+//
+// On Windows it used to open CONIN$/CONOUT$ and query the console instead, which
+// left any program with redirected stdio -- a service, a CI job -- waiting on a
+// console that never replies.
+func TestBackgroundColorDoesNotQueryNonTerminals(t *testing.T) {
+	r, w := pipe(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := BackgroundColor(r, w)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("want an error for handles that are not terminals, got nil")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("BackgroundColor blocked on handles that are not terminals")
+	}
+}
+
+// The documented fallback: assume a dark background when detection is not possible.
+func TestHasDarkBackgroundDefaultsToDarkOnNonTerminals(t *testing.T) {
+	r, w := pipe(t)
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- HasDarkBackground(r, w)
+	}()
+
+	select {
+	case isDark := <-done:
+		if !isDark {
+			t.Error("want the dark default when detection is not possible, got false")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("HasDarkBackground blocked on handles that are not terminals")
+	}
+}
+
+func pipe(t *testing.T) (r, w *os.File) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	return r, w
+}


### PR DESCRIPTION
---

Found while tracking down a start-up hang in [tea](https://gitea.com/gitea/tea), the Gitea CLI,
which blocks forever on Windows when its stdio is redirected: https://gitea.com/gitea/tea/issues/1053

## The problem

On Windows, `BackgroundColor` replaces any handle that is not a terminal with `CONIN$`/`CONOUT$`
and queries the console instead:

```go
if runtime.GOOS == "windows" {
    if !term.IsTerminal(in.Fd()) {
        f, err := os.OpenFile("CONIN$", os.O_RDWR, 0o644)
        ...
        in = f
    }
    ...
}
```

So a program whose stdio is redirected — a Windows service, a CI job — writes an OSC 11 query to a
console nobody is watching, and then waits for a reply that never comes. Redirecting stdio does not
protect you, which is surprising: on Unix the same function returns `input/output is not a terminal`
and gives up.

There is a 2 second timeout on the read, but it does not currently fire, because the `CONIN$` handle
this code creates defeats ultraviolet's cancel reader. That is a separate bug and I have opened
https://github.com/charmbracelet/ultraviolet/pull/138 for it. With that fixed, the behaviour here becomes a 2 second stall per call instead of
a hang — better, but still wrong for a program that is only trying to print a version string.

## The fix

Do what Unix already does: if the handles the caller passed are not terminals, say so and return.

The caller chose those handles. If output is going to a pipe, the console's background colour is
not the question being asked, and adaptive colour has nothing to adapt to. A caller that genuinely
wants to talk to the console can open `CONIN$`/`CONOUT$` and pass them in — the API takes explicit
handles, so that option is still there.

The Windows branch stays, because console input and output are separate handles and must be queried
as a pair rather than treating either one as bidirectional.

I realise this deletes a deliberate special case, so I am happy to be told the intent was something
I have missed. If the redirected-stdio path needs to stay, the alternative is to keep it and rely on
the ultraviolet fix to bound it — but then every non-interactive Windows program pays a 2 second
stall on start-up, and via the `compat` package it pays it before `main()` runs.

## Tests

`query_test.go`, cross-platform, using `os.Pipe()` handles:

- `BackgroundColor` must report that pipes are not terminals, and return rather than wait
- `HasDarkBackground` must fall back to its documented dark default

The first fails against `main` on Windows — it returns no error, because it went and queried the
console anyway. Both pass with the fix. Full suite passes.

## Unrelated, but worth flagging

`compat` runs this query from package-level vars:

```go
var (
    HasDarkBackground = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
    Profile           = colorprofile.Detect(os.Stdout, os.Environ())
)
```

Importing that package for a type — `compat.AdaptiveColor` — therefore makes a program query the
terminal before `main()` runs. That is how tea ended up hanging on `tea --version`. It cannot be
made lazy without changing the exported `bool` to a function, so I have not touched it here, but it
seems worth a look.