### PR TITLE
Rgb and hsl color string format support

### DIFF
--- a/color.go
+++ b/color.go
@@ -98,11 +98,19 @@ func Color(s string) color.Color {
 
 	// RGB format
 	c, err := parseRgb(s)
-	if err != nil {
-		return noColor
+	if err == nil {
+		return c
 	}
 
-	return c
+	// HSL format
+	c, err = parseHsl(s)
+	if err == nil {
+		return c
+	}
+
+	return noColor
+}
+
 // hueToRgb converts a normalized hue value into an RGB channel value. The p and
 // q parameters define the color bounds, and t specifies the hue position for
 // the channel being calculated. The returned value is normalized between 0 and 1.

--- a/color.go
+++ b/color.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"errors"
 	"image/color"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -102,6 +103,28 @@ func Color(s string) color.Color {
 	}
 
 	return c
+// hueToRgb converts a normalized hue value into an RGB channel value. The p and
+// q parameters define the color bounds, and t specifies the hue position for
+// the channel being calculated. The returned value is normalized between 0 and 1.
+func hueToRgb(p, q, t float64) float64 {
+	if t < 0 {
+		t += 1
+	}
+	if t > 1 {
+		t -= 1
+	}
+
+	if t < 1.0/6.0 {
+		return p + (q-p)*6*t
+	}
+	if t < 1.0/2.0 {
+		return q
+	}
+	if t < 2.0/3.0 {
+		return p + (q-p)*(2.0/3.0-t)*6
+	}
+
+	return p
 }
 
 var errInvalidFormat = errors.New("invalid hex format") // pre-allocated.
@@ -142,6 +165,65 @@ func parseHex(s string) (c color.RGBA, err error) {
 		err = errInvalidFormat
 	}
 	return c, err
+}
+
+// parseHsl parses a string of hsl format and returns a color.RGBA. The string can
+// be in the format hsl(h, s%, l%) where h is the hue, s is the saturation, and
+// l is the lightness. Values outside the valid range are clamped or normalized.
+func parseHsl(s string) (color.RGBA, error) {
+	reHSL := regexp.MustCompile(`^hsl\(\s*(-?\d+)\s*,\s*(-?\d+)\s*%\s*,\s*(-?\d+)\s*%\s*\)$`)
+
+	m := reHSL.FindStringSubmatch(s)
+	if m == nil {
+		return color.RGBA{}, errInvalidFormat
+	}
+
+	light, _ := strconv.Atoi(m[3])
+	if light <= 0 {
+		return color.RGBA{R: 0x00, G: 0x00, B: 0x00, A: 0xff}, nil
+	}
+	if light >= 100 {
+		return color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, nil
+	}
+
+	sat, _ := strconv.Atoi(m[2])
+	if sat <= 0 {
+		lightHex := uint8((light * 255) / 100)
+		return color.RGBA{R: lightHex, G: lightHex, B: lightHex, A: 0xff}, nil
+	}
+	if sat > 100 {
+		sat = 100
+	}
+
+	h, _ := strconv.Atoi(m[1])
+	h %= 360
+	for h < 0 {
+		h += 360
+	}
+	// Convert HSL values from percentages to [0,1]
+	hf := float64(h) / 360.0
+	sf := float64(sat) / 100.0
+	lf := float64(light) / 100.0
+
+	var q float64
+	if lf < 0.5 {
+		q = lf * (1 + sf)
+	} else {
+		q = lf + sf - lf*sf
+	}
+
+	p := 2*lf - q
+
+	r := hueToRgb(p, q, hf+1.0/3.0)
+	g := hueToRgb(p, q, hf)
+	b := hueToRgb(p, q, hf-1.0/3.0)
+
+	return color.RGBA{
+		R: uint8(math.Round(r * 255)),
+		G: uint8(math.Round(g * 255)),
+		B: uint8(math.Round(b * 255)),
+		A: 0xff,
+	}, nil
 }
 
 // parseRgb parses a string of rgb format and returns a color.RGBA. The string can

--- a/color.go
+++ b/color.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"errors"
 	"image/color"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -66,6 +67,8 @@ func (n NoColor) RGBA() (r, g, b, a uint32) {
 //	ansi256Color := lipgloss.Color("21")
 //	hexColor := lipgloss.Color("#0000ff")
 func Color(s string) color.Color {
+
+	// Hex format
 	if strings.HasPrefix(s, "#") {
 		c, err := parseHex(s)
 		if err != nil {
@@ -74,24 +77,31 @@ func Color(s string) color.Color {
 		return c
 	}
 
+	// Ansi format
 	i, err := strconv.Atoi(s)
+	if err == nil {
+		if i < 0 {
+			// Only positive numbers
+			i = -i
+		}
+
+		if i < 16 {
+			return ansi.BasicColor(i) //nolint:gosec
+		} else if i < 256 {
+			return ANSIColor(i) //nolint:gosec
+		}
+
+		r, g, b := uint8((i>>16)&0xff), uint8(i>>8&0xff), uint8(i&0xff) //nolint:gosec
+		return color.RGBA{R: r, G: g, B: b, A: 0xff}
+	}
+
+	// RGB format
+	c, err := parseRgb(s)
 	if err != nil {
 		return noColor
 	}
 
-	if i < 0 {
-		// Only positive numbers
-		i = -i
-	}
-
-	if i < 16 {
-		return ansi.BasicColor(i) //nolint:gosec
-	} else if i < 256 {
-		return ANSIColor(i) //nolint:gosec
-	}
-
-	r, g, b := uint8((i>>16)&0xff), uint8(i>>8&0xff), uint8(i&0xff) //nolint:gosec
-	return color.RGBA{R: r, G: g, B: b, A: 0xff}
+	return c
 }
 
 var errInvalidFormat = errors.New("invalid hex format") // pre-allocated.
@@ -132,6 +142,32 @@ func parseHex(s string) (c color.RGBA, err error) {
 		err = errInvalidFormat
 	}
 	return c, err
+}
+
+// parseRgb parses a string of rgb format and returns a color.RGBA. The string can
+// be in the format rgb(r, g, b) where r, g, and b are numbers.
+func parseRgb(s string) (c color.RGBA, err error) {
+	reRGB := regexp.MustCompile(`^rgb\(\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*\)$`)
+	m := reRGB.FindStringSubmatch(s)
+	if m == nil {
+		return color.RGBA{}, errInvalidFormat
+	}
+	values := [3]int{}
+	for i, str := range m[1:4] {
+		values[i], _ = strconv.Atoi(str)
+		if values[i] < 0 {
+			values[i] = 0
+		}
+		if values[i] > 255 {
+			values[i] = 255
+		}
+	}
+	return color.RGBA{
+		R: uint8(values[0]),
+		G: uint8(values[1]),
+		B: uint8(values[2]),
+		A: 0xff,
+	}, nil
 }
 
 // RGBColor is a color specified by red, green, and blue values.

--- a/color_test.go
+++ b/color_test.go
@@ -311,7 +311,7 @@ func TestLighten(t *testing.T) {
 	}
 }
 
-func TestRgbFormat(t *testing.T) {
+func TestParseRgb(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string

--- a/color_test.go
+++ b/color_test.go
@@ -380,3 +380,79 @@ func TestParseRgb(t *testing.T) {
 		})
 	}
 }
+
+func TestParseHsl(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    color.Color
+		expectError bool
+	}{
+		{name: "valid-hsl-single-sapces-red", input: "hsl(0, 100%, 50%)", expected: hex("#FF0000")},
+		{name: "valid-hsl-single-sapces-green", input: "hsl(120, 100%, 50%)", expected: hex("#00FF00")},
+		{name: "valid-hsl-single-sapces-blue", input: "hsl(240, 100%, 50%)", expected: hex("#0000FF")},
+		{name: "valid-hsl-single-sapces-white", input: "hsl(0, 0%, 100%)", expected: hex("#FFFFFF")},
+		{name: "valid-hsl-single-sapces-white-yellow-hue", input: "hsl(180, 50%, 100%)", expected: hex("#FFFFFF")},
+		{name: "valid-hsl-single-sapces-black-yellow-hue", input: "hsl(180, 50%, 0%)", expected: hex("#000000")},
+		{name: "valid-hsl-single-sapces-black", input: "hsl(0, 0%, 0%)", expected: hex("#000000")},
+		{name: "valid-hsl-single-sapces-gray", input: "hsl(0, 0%, 50%)", expected: hex("#7F7F7F")},
+		{name: "valid-hsl-single-sapces-pink", input: "hsl(0, 100%, 75%)", expected: hex("#ff8080")},
+		{name: "valid-hsl-single-sapces-light-green", input: "hsl(120, 100%, 75%)", expected: hex("#80ff80")},
+		{name: "valid-hsl-single-sapces-dark-blue", input: "hsl(240, 100%, 25%)", expected: hex("#000080")},
+		{name: "valid-hsl-no-sapces-red", input: "hsl(0,100%,50%)", expected: hex("#FF0000")},
+		{name: "valid-hsl-no-sapces-green", input: "hsl(120,100%,50%)", expected: hex("#00FF00")},
+		{name: "valid-hsl-no-sapces-blue", input: "hsl(240,100%,50%)", expected: hex("#0000FF")},
+		{name: "valid-hsl-no-sapces-white", input: "hsl(0,0%,100%)", expected: hex("#FFFFFF")},
+		{name: "valid-hsl-no-sapces-black", input: "hsl(0,0%,0%)", expected: hex("#000000")},
+		{name: "valid-hsl-no-sapces-gray", input: "hsl(0,0%,50%)", expected: hex("#7F7F7F")},
+		{name: "valid-hsl-inconsistent-single-sapces-red", input: "hsl( 0,100%,50%)", expected: hex("#FF0000")},
+		{name: "valid-hsl-inconsistent-single-sapces-green", input: "hsl(120 ,100%,50%)", expected: hex("#00FF00")},
+		{name: "valid-hsl-inconsistent-single-sapces-blue", input: "hsl(240, 100%,50%)", expected: hex("#0000FF")},
+		{name: "valid-hsl-inconsistent-single-sapces-white", input: "hsl(0,0% ,100%)", expected: hex("#FFFFFF")},
+		{name: "valid-hsl-inconsistent-single-sapces-black", input: "hsl(0,0%, 0%)", expected: hex("#000000")},
+		{name: "valid-hsl-inconsistent-single-sapces-gray", input: "hsl(0,0%,50% )", expected: hex("#7F7F7F")},
+		{name: "valid-hsl-inconsistent-multiple-sapces-red", input: "hsl(     0, 100%, 50%)", expected: hex("#FF0000")},
+		{name: "valid-hsl-inconsistent-multiple-sapces-green", input: "hsl(120   , 100%, 50%)", expected: hex("#00FF00")},
+		{name: "valid-hsl-inconsistent-multiple-sapces-blue", input: "hsl(240,   100%, 50%)", expected: hex("#0000FF")},
+		{name: "valid-hsl-inconsistent-multiple-sapces-white", input: "hsl(0, 0%,       100%)", expected: hex("#FFFFFF")},
+		{name: "valid-hsl-inconsistent-multiple-sapces-black", input: "hsl(0, 0%, 0%       )", expected: hex("#000000")},
+		{name: "valid-hsl-inconsistent-multiple-sapces-gray", input: "hsl(0, 0%,         50%)", expected: hex("#7F7F7F")},
+		{name: "valid-hsl-out-of-range-negative-cyan", input: "hsl(-180, 50%, 50%)", expected: hex("#40bfbf")},
+		{name: "valid-hsl-out-of-range-red", input: "hsl(360, 100%, 50%)", expected: hex("#FF0000")},
+		{name: "valid-hsl-gray", input: "hsl(360, 0%, 50%)", expected: hex("#7F7F7F")},
+		{name: "no-percentage", input: "hsl(0, 1, 0)", expectError: true},
+		{name: "two-values", input: "hsl(255, 0%)", expectError: true},
+		{name: "four-values", input: "hsl(0, 50%, 50%, 100)", expectError: true},
+		{name: "four-values-percentage", input: "hsl(0, 50%, 50%, 100%)", expectError: true},
+		{name: "upper-case", input: "HSL(0, 100%, 50%)", expectError: true},
+		{name: "no-values", input: "hsl(, , )", expectError: true},
+		{name: "no-values-percentages", input: "hsl(, %, %)", expectError: true},
+		{name: "missing )", input: "hsl(240, 100%, 50%", expectError: true},
+		{name: "unexpected rune (", input: "hsl((120 ,100%,50%)", expectError: true},
+		{name: "unexpected rune .", input: "hsl(0. 0%, 100%)", expectError: true},
+		{name: "unexpected rune b", input: "hsl(180, b50%, 0%)", expectError: true},
+		{name: "unexpected float", input: "hsl(0, 100%, 55.5%)", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseHsl(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("parseHsl() expected error but got none for input %q", tt.input)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parseHsl() unexpected error for input %q: %v", tt.input, err)
+				return
+			}
+
+			expectColorMatches(t, result, tt.expected)
+		})
+	}
+}

--- a/color_test.go
+++ b/color_test.go
@@ -310,3 +310,73 @@ func TestLighten(t *testing.T) {
 		})
 	}
 }
+
+func TestRgbFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    color.Color
+		expectError bool
+	}{
+		{name: "valid-rgb-single-sapces-red", input: "rgb(255, 0, 0)", expected: hex("#FF0000")},
+		{name: "valid-rgb-single-sapces-green", input: "rgb(0, 255, 0)", expected: hex("#00FF00")},
+		{name: "valid-rgb-single-sapces-blue", input: "rgb(0, 0, 255)", expected: hex("#0000FF")},
+		{name: "valid-rgb-single-sapces-white", input: "rgb(255, 255, 255)", expected: hex("#FFFFFF")},
+		{name: "valid-rgb-single-sapces-black", input: "rgb(0, 0, 0)", expected: hex("#000000")},
+		{name: "valid-rgb-single-sapces-gray", input: "rgb(128, 128, 128)", expected: hex("#808080")},
+		{name: "valid-rgb-no-sapces-red", input: "rgb(255,0,0)", expected: hex("#FF0000")},
+		{name: "valid-rgb-no-sapces-green", input: "rgb(0,255,0)", expected: hex("#00FF00")},
+		{name: "valid-rgb-no-sapces-blue", input: "rgb(0,0,255)", expected: hex("#0000FF")},
+		{name: "valid-rgb-no-sapces-white", input: "rgb(255,255,255)", expected: hex("#FFFFFF")},
+		{name: "valid-rgb-no-sapces-black", input: "rgb(0,0,0)", expected: hex("#000000")},
+		{name: "valid-rgb-no-sapces-gray", input: "rgb(128,128,128)", expected: hex("#808080")},
+		{name: "valid-rgb-inconsistent-single-sapces-red", input: "rgb(255,0,0 )", expected: hex("#FF0000")},
+		{name: "valid-rgb-inconsistent-single-sapces-green", input: "rgb(0,255, 0)", expected: hex("#00FF00")},
+		{name: "valid-rgb-inconsistent-single-sapces-blue", input: "rgb(0,0 ,255)", expected: hex("#0000FF")},
+		{name: "valid-rgb-inconsistent-single-sapces-white", input: "rgb(255, 255,255)", expected: hex("#FFFFFF")},
+		{name: "valid-rgb-inconsistent-single-sapces-black", input: "rgb(0 ,0,0)", expected: hex("#000000")},
+		{name: "valid-rgb-inconsistent-single-sapces-gray", input: "rgb( 128,128,128)", expected: hex("#808080")},
+		{name: "valid-rgb-inconsistent-multiple-sapces-red", input: "rgb(255  ,0,0 )", expected: hex("#FF0000")},
+		{name: "valid-rgb-inconsistent-multiple-sapces-green", input: "rgb(0,    255, 0)", expected: hex("#00FF00")},
+		{name: "valid-rgb-inconsistent-multiple-sapces-blue", input: "rgb(0,0 ,   255)", expected: hex("#0000FF")},
+		{name: "valid-rgb-inconsistent-multiple-sapces-white", input: "rgb(255, 255,255  )", expected: hex("#FFFFFF")},
+		{name: "valid-rgb-inconsistent-multiple-sapces-black", input: "rgb(        0 ,0,0)", expected: hex("#000000")},
+		{name: "valid-rgb-inconsistent-multiple-sapces-gray", input: "rgb( 128    , 128  , 128 )", expected: hex("#808080")},
+		{name: "valid-rgb-out-of-range-red", input: "rgb(256, -1, -1)", expected: hex("#FF0000")},
+		{name: "valid-rgb-out-of-range-green", input: "rgb(-255, 512, -255)", expected: hex("#00FF00")},
+		{name: "valid-rgb-out-of-range-blue", input: "rgb(-100, -200, 300)", expected: hex("#0000FF")},
+		{name: "valid-rgb-out-of-range-white", input: "rgb(500, 1000, 1500)", expected: hex("#FFFFFF")},
+		{name: "valid-rgb-out-of-range-black", input: "rgb(-10, -100, -1000)", expected: hex("#000000")},
+		{name: "two-values", input: "rgb(255, 0)", expectError: true},
+		{name: "four-values", input: "rgb(0,255, 0, 255)", expectError: true},
+		{name: "upper-case", input: "RGB(255, 0, 0)", expectError: true},
+		{name: "no-values", input: "rgb(, , )", expectError: true},
+		{name: "missing )", input: "rgb(0, 255, 0", expectError: true},
+		{name: "unexpected rune (", input: "rgb((0, 0, 255)", expectError: true},
+		{name: "unexpected rune .", input: "rgb(255. 255, 255)", expectError: true},
+		{name: "unexpected rune b", input: "rgb(0, b0, 0)", expectError: true},
+		{name: "unexpected float", input: "rgb(255, 31.415, 0)", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseRgb(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("parseRgb() expected error but got none for input %q", tt.input)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parseRgb() unexpected error for input %q: %v", tt.input, err)
+				return
+			}
+
+			expectColorMatches(t, result, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

I have created a discussion but it has not been approved at this time. I wanted to use this feature in my own fork, so I developed it, and decided to go ahead and offer you my implementation. I understand if you decide that my idea is not within scope and you reject my commit. I wanted to suggest it never the less.

I created the discussion here: https://github.com/charmbracelet/lipgloss/discussions/718

The HSL to RGB conversion was made with an implementation discussed here:
- [https://stackoverflow.com/questions/2353211/hsl-to-rgb-color-conversion](https://stackoverflow.com/questions/2353211/hsl-to-rgb-color-conversion)