### PR TITLE
perf(wrap): forward bytes in runs instead of one at a time

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -12,6 +12,9 @@ import (
 func Wrap(s string, width int, breakpoints string) string {
 	var buf bytes.Buffer
 	s = ansi.Wrap(s, width, breakpoints)
+	// The writer only inserts resets around newlines, so the output is
+	// the same length as the input plus a little. Size it once.
+	buf.Grow(len(s) + len(s)/8)
 	w := NewWrapWriter(&buf)
 	defer w.Close() //nolint:errcheck
 	_, _ = io.WriteString(w, s)

--- a/wrap.go
+++ b/wrap.go
@@ -69,27 +69,39 @@ func (w *WrapWriter) Write(p []byte) (int, error) {
 		// nested writer chains; treat it as a no-op rather than panicking.
 		return len(p), nil
 	}
+	// Bytes are forwarded in runs rather than one at a time: only a
+	// newline needs anything written around it, so everything between
+	// newlines is a single downstream Write instead of one per byte.
+	start := 0
 	for i := range p {
 		b := p[i]
 		w.p.Advance(b)
-		if b == '\n' {
-			if !w.style.IsZero() {
-				_, _ = w.w.Write([]byte(ansi.ResetStyle))
-			}
-			if !w.link.IsZero() {
-				_, _ = w.w.Write([]byte(ansi.ResetHyperlink()))
-			}
+		if b != '\n' {
+			continue
 		}
 
-		_, _ = w.w.Write([]byte{b})
-		if b == '\n' {
-			if !w.link.IsZero() {
-				_, _ = w.w.Write([]byte(ansi.SetHyperlink(w.link.URL, w.link.Params)))
-			}
-			if !w.style.IsZero() {
-				_, _ = w.w.Write([]byte(w.style.String()))
-			}
+		if i > start {
+			_, _ = w.w.Write(p[start:i])
 		}
+		if !w.style.IsZero() {
+			_, _ = w.w.Write([]byte(ansi.ResetStyle))
+		}
+		if !w.link.IsZero() {
+			_, _ = w.w.Write([]byte(ansi.ResetHyperlink()))
+		}
+
+		_, _ = w.w.Write(p[i : i+1])
+		start = i + 1
+
+		if !w.link.IsZero() {
+			_, _ = w.w.Write([]byte(ansi.SetHyperlink(w.link.URL, w.link.Params)))
+		}
+		if !w.style.IsZero() {
+			_, _ = w.w.Write([]byte(w.style.String()))
+		}
+	}
+	if start < len(p) {
+		_, _ = w.w.Write(p[start:])
 	}
 
 	return len(p), nil


### PR DESCRIPTION
`WrapWriter.Write` allocated a fresh `[]byte{b}` for **every input byte** and pushed each one separately through the downstream chain:

```go
for i := range p {
    b := p[i]
    w.p.Advance(b)
    ...
    _, _ = w.w.Write([]byte{b})   // escapes into an interface method -> heap alloc, per byte
}
```

Only a newline needs anything written around it (the style/link reset and reapply), so everything between newlines can go downstream in a single `Write`. The parser still sees every byte.

Second commit sizes the buffer in `Wrap` up front instead of doubling from zero.

### Why it matters

Glamour stacks two of these writers in series, so a rendered document pays this twice. Profiling a glamour render, `WrapWriter.Write` accounted for **93.5% of all allocations** — 2.6M objects flat, 8.1M cumulative once the per-byte writes cascaded through the chain.

Measured against glamour at `main`, rendering a 17 KB markdown document:

| | before | after |
|---|---|---|
| prose | 498,475 allocs | **79,980** (6.2x fewer) |
| mixed markdown | 1,982,828 allocs | **442,737** (4.5x fewer) |

Roughly 20-25% faster on both.

This composes with charmbracelet/glamour's companion PR, which removes a per-cell style rebuild. Each change partly masks the other, so together they are worth much more than the sum: same document goes to **8,291 allocations** (60x) and **2.24x faster** with both.

### Correctness

Output is unchanged byte for byte. Verified by rendering through glamour across 6 styles x 5 widths x 5 document types — 6.3 MB of output, `cmp`-identical — including CJK, emoji ZWJ sequences, regional-indicator flags and combining marks. Lip Gloss's own suite passes.

No API change; both commits are internal to `wrap.go`.
